### PR TITLE
Detected Twitter link when there are contact details

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -87,11 +87,12 @@ module Everypolitician
       def twitter
         if key?(:contact_details)
           if twitter_contact = self[:contact_details].find { |d| d[:type] == 'twitter' }
-            twitter_contact[:value].strip
+            return twitter_contact[:value].strip
           end
-        elsif key?(:links)
+        end
+        if key?(:links)
           if twitter_link = self[:links].find { |d| d[:note][/twitter/i] }
-            twitter_link[:url].strip
+            return twitter_link[:url].strip
           end
         end
       end

--- a/test/everypolitician/popolo_test.rb
+++ b/test/everypolitician/popolo_test.rb
@@ -33,6 +33,14 @@ class Everypolitician::PopoloTest < Minitest::Test
     assert_equal 'https://twitter.com/bob', person.twitter
   end
 
+  def test_person_contact_details_and_twitter_links
+    person = Everypolitician::Popolo::Person.new(
+      contact_details: [{ note: 'cell', value: '+1-555-555-0100' }],
+      links: [{ note: 'twitter', url: 'https://twitter.com/bob' }]
+    )
+    assert_equal 'https://twitter.com/bob', person.twitter
+  end
+
   def test_accessing_basic_person_attributes
     person = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob', other_names: [])
     assert_equal '123', person.id


### PR DESCRIPTION
If a persons has some contact_details, but the only Twitter related
thing they have is a link then we should fall back to returning the
Twitter link.

Originally raised by @tmtmtmtm in https://github.com/everypolitician/everypolitician-popolo/commit/c87e557139775b0ef4518962f5bf166f36ac2b39#commitcomment-15972516
