### PR TITLE
Allow #identifier to return identifiers other than wikidata

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -85,7 +85,7 @@ module Everypolitician
       end
 
       def identifier(scheme)
-        identifiers.find(->{{}}) { |i| i[:scheme] == 'wikidata' }[:identifier]
+        identifiers.find(->{{}}) { |i| i[:scheme] == scheme }[:identifier]
       end
 
       def email

--- a/test/everypolitician/popolo_test.rb
+++ b/test/everypolitician/popolo_test.rb
@@ -81,6 +81,18 @@ class Everypolitician::PopoloTest < Minitest::Test
     assert_equal 'https://www.facebook.com/bob', person.facebook
   end
 
+  def test_person_identifier
+    person = Everypolitician::Popolo::Person.new(
+      identifiers: [
+        { scheme: 'foo', identifier: 'bar' },
+        { scheme: 'wikidata', identifier: 'zap' }
+      ]
+    )
+
+    assert_equal 'bar', person.identifier('foo')
+    assert_equal 'zap', person.identifier('wikidata')
+  end
+
   def test_person_wikidata
     person = Everypolitician::Popolo::Person.new({})
     assert_nil person.wikidata


### PR DESCRIPTION
Currently the #identifier method can only be used to return identifiers
with the scheme 'wikidata'. I'd like to use it to return other id’s.

This commit changes the #identifier method to enable lookups of
identifiers by their scheme. This was the functionality I was expecting
from the method when I tried to use it.

The #wikidata method can still be used to return a 'wikidata' identifier, so
no functionality is lost. You can also use `person.identifier('wikidata')` to
access it.
