### PR TITLE
Cover Popolo Areas

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -28,6 +28,10 @@ module Everypolitician
       def organizations
         Organizations.new(popolo[:organizations])
       end
+
+      def areas
+        Areas.new(popolo[:areas])
+      end
     end
 
     class Collection
@@ -159,6 +163,21 @@ module Everypolitician
         id == other.id
       end
       alias eql? ==
+    end
+
+    class Areas < Collection
+      def initialize(documents)
+        @documents = documents.map { |p| Area.new(p) }
+      end
+    end
+
+    class Area
+      def initialize(document)
+        @document = document
+        document.each do |key, value|
+          define_singleton_method(key) { value }
+        end
+      end
     end
   end
 end

--- a/test/everypolitician/popolo_test.rb
+++ b/test/everypolitician/popolo_test.rb
@@ -192,8 +192,9 @@ class Everypolitician::PopoloTest < Minitest::Test
     popolo = Everypolitician::Popolo::JSON.new(
       areas: [{ id: '123', name: 'Newtown', type: 'constituency' }]
     )
-    assert_instance_of Everypolitician::Popolo::Areas, popolo.areas
     area = popolo.areas.first
+
+    assert_instance_of Everypolitician::Popolo::Areas, popolo.areas
     assert_instance_of Everypolitician::Popolo::Area, area
   end
 end

--- a/test/everypolitician/popolo_test.rb
+++ b/test/everypolitician/popolo_test.rb
@@ -197,4 +197,15 @@ class Everypolitician::PopoloTest < Minitest::Test
     assert_instance_of Everypolitician::Popolo::Areas, popolo.areas
     assert_instance_of Everypolitician::Popolo::Area, area
   end
+
+  def test_accessing_area_properties
+    popolo = Everypolitician::Popolo::JSON.new(
+      areas: [{ id: '123', name: 'Newtown', type: 'constituency' }]
+    )
+    area = popolo.areas.first
+
+    assert_equal '123', area.id
+    assert_equal 'Newtown', area.name
+    assert_equal 'constituency', area.type
+  end
 end

--- a/test/everypolitician/popolo_test.rb
+++ b/test/everypolitician/popolo_test.rb
@@ -187,4 +187,13 @@ class Everypolitician::PopoloTest < Minitest::Test
     just_org_1 = Everypolitician::Popolo::Organizations.new([org1])
     assert_equal [Everypolitician::Popolo::Organization.new(org2)], all_orgs - just_org_1
   end
+
+  def test_reading_popolo_areas
+    popolo = Everypolitician::Popolo::JSON.new(
+      areas: [{ id: '123', name: 'Newtown', type: 'constituency' }]
+    )
+    assert_instance_of Everypolitician::Popolo::Areas, popolo.areas
+    area = popolo.areas.first
+    assert_instance_of Everypolitician::Popolo::Area, area
+  end
 end


### PR DESCRIPTION
In [publicwhip](https://github.com/OPORA/publicwhip) we access [Popolo Area](http://www.popoloproject.com/specs/area.html) data to add information to people’s memberships:

```
member.constituency = area["name"]
```

Currently [we pull the area data out of Popolo JSON](https://github.com/OPORA/publicwhip/blob/develop/lib/data_loader/ukraine/people.rb#L13), but if this gem supported Area we could use the handy methods like `popolo.persons`, `popolo.organizations` consistently.

These commits add bare bones Area support, based on the Organization and People implementations.
