### PR TITLE
Allow empty collections

### DIFF
--- a/lib/everypolitician/popolo/area.rb
+++ b/lib/everypolitician/popolo/area.rb
@@ -2,7 +2,7 @@ module Everypolitician
   module Popolo
     class Areas < Collection
       def initialize(documents)
-        @documents = documents.map { |p| Area.new(p) }
+        @documents = documents ? documents.map { |p| Area.new(p) } : []
       end
     end
 

--- a/lib/everypolitician/popolo/area.rb
+++ b/lib/everypolitician/popolo/area.rb
@@ -1,10 +1,6 @@
 module Everypolitician
   module Popolo
-    class Areas < Collection
-      def initialize(documents)
-        @documents = documents ? documents.map { |p| Area.new(p) } : []
-      end
-    end
+    class Areas < Collection; end
 
     class Area
       def initialize(document)

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -5,6 +5,10 @@ module Everypolitician
 
       attr_reader :documents
 
+      def initialize(documents)
+        @documents = documents ? documents.map { |p| klass.new(p) } : []
+      end
+
       def each(&block)
         documents.each(&block)
       end
@@ -12,6 +16,27 @@ module Everypolitician
       def -(other)
         other_ids = Set.new(other.documents.map(&:id))
         documents.reject { |d| other_ids.include?(d.id) }
+      end
+
+      private
+
+      # TODO: This feels pretty nasty, is there a better way of working out the
+      # class name?
+      def klass
+        case self.class.to_s.split("::").last
+        when "People"
+          Person
+        when "Organizations"
+          Organization
+        when "Memberships"
+          Membership
+        when "Events"
+          Event
+        when "Areas"
+          Area
+        else
+          raise "Unknown class: #{self.class.to_s}"
+        end
       end
     end
   end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,10 +1,6 @@
 module Everypolitician
   module Popolo
-    class Events < Collection
-      def initialize(documents)
-        @documents = documents ? documents.map { |p| Event.new(p) } : []
-      end
-    end
+    class Events < Collection; end
 
     class Event
       def initialize(document)

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -2,7 +2,7 @@ module Everypolitician
   module Popolo
     class Events < Collection
       def initialize(documents)
-        @documents = documents.map { |p| Event.new(p) }
+        @documents = documents ? documents.map { |p| Event.new(p) } : []
       end
     end
 

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -1,10 +1,6 @@
 module Everypolitician
   module Popolo
-    class Memberships < Collection
-      def initialize(documents)
-        @documents = documents ? documents.map { |p| Membership.new(p) } : []
-      end
-    end
+    class Memberships < Collection; end
 
     class Membership
       def initialize(document)

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -2,7 +2,7 @@ module Everypolitician
   module Popolo
     class Memberships < Collection
       def initialize(documents)
-        @documents = documents.map { |p| Membership.new(p) }
+        @documents = documents ? documents.map { |p| Membership.new(p) } : []
       end
     end
 

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -2,7 +2,7 @@ module Everypolitician
   module Popolo
     class Organizations < Collection
       def initialize(documents)
-        @documents = documents.map { |p| Organization.new(p) }
+        @documents = documents ? documents.map { |p| Organization.new(p) } : []
       end
     end
 

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -1,10 +1,6 @@
 module Everypolitician
   module Popolo
-    class Organizations < Collection
-      def initialize(documents)
-        @documents = documents ? documents.map { |p| Organization.new(p) } : []
-      end
-    end
+    class Organizations < Collection; end
 
     class Organization
       attr_reader :document

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -1,10 +1,6 @@
 module Everypolitician
   module Popolo
-    class People < Collection
-      def initialize(documents)
-        @documents = documents ? documents.map { |p| Person.new(p) } : []
-      end
-    end
+    class People < Collection; end
 
     class Person
       class Error < StandardError; end

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -2,7 +2,7 @@ module Everypolitician
   module Popolo
     class People < Collection
       def initialize(documents)
-        @documents = documents.map { |p| Person.new(p) }
+        @documents = documents ? documents.map { |p| Person.new(p) } : []
       end
     end
 

--- a/test/everypolitician/popolo/area_test.rb
+++ b/test/everypolitician/popolo/area_test.rb
@@ -11,6 +11,11 @@ class Everypolitician::AreaTest < Minitest::Test
     assert_instance_of Everypolitician::Popolo::Area, area
   end
 
+  def test_no_areas_in_popolo_data
+    popolo = Everypolitician::Popolo::JSON.new(other_data: [{ id: '123', foo: 'Bar' }])
+    assert_equal true, popolo.areas.none?
+  end
+
   def test_accessing_area_properties
     popolo = Everypolitician::Popolo::JSON.new(
       areas: [{ id: '123', name: 'Newtown', type: 'constituency' }]

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -11,6 +11,11 @@ class Everypolitician::EventTest < Minitest::Test
     assert_instance_of Everypolitician::Popolo::Event, event
   end
 
+  def test_no_events_in_popolo_data
+    popolo = Everypolitician::Popolo::JSON.new(other_data: [{ id: '123', foo: 'Bar' }])
+    assert_equal true, popolo.events.none?
+  end
+
   def test_accessing_event_properties
     popolo = Everypolitician::Popolo::JSON.new(
       events: [{ id: 'term/8', name: '8th Verkhovna Rada', start_date: '2014-11-27' }]

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -18,6 +18,11 @@ class Everypolitician::MembershipTest < Minitest::Test
     assert_instance_of Everypolitician::Popolo::Membership, membership
   end
 
+  def test_no_memberships_in_popolo_data
+    popolo = Everypolitician::Popolo::JSON.new(other_data: [{ id: '123', foo: 'Bar' }])
+    assert_equal true, popolo.memberships.none?
+  end
+
   def test_membership_start_date_method_always_present
     member_with_no_start_date = Everypolitician::Popolo::Membership.new({})
     member_with_start_date = Everypolitician::Popolo::Membership.new({start_date: "2016-01-01"})

--- a/test/everypolitician/popolo/organization_test.rb
+++ b/test/everypolitician/popolo/organization_test.rb
@@ -8,6 +8,11 @@ class Everypolitician::OrganizationTest < Minitest::Test
     assert_instance_of Everypolitician::Popolo::Organization, organization
   end
 
+  def test_no_organizations_in_popolo_data
+    popolo = Everypolitician::Popolo::JSON.new(other_data: [{ id: '123', foo: 'Bar' }])
+    assert_equal true, popolo.organizations.none?
+  end
+
   def test_accessing_organization_properties
     popolo = Everypolitician::Popolo::JSON.new(organizations: [{ id: '123', name: 'ACME' }])
     organization = popolo.organizations.first

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -8,6 +8,11 @@ class Everypolitician::PersonTest < Minitest::Test
     assert_instance_of Everypolitician::Popolo::Person, person
   end
 
+  def test_no_persons_in_popolo_data
+    popolo = Everypolitician::Popolo::JSON.new(other_data: [{ id: '123', foo: 'Bar' }])
+    assert_equal true, popolo.persons.none?
+  end
+
   def test_accessing_person_properties
     popolo = Everypolitician::Popolo::JSON.new(persons: [{ id: '123', name: 'Bob' }])
     person = popolo.persons.first


### PR DESCRIPTION
Right now an exception is thrown if you try to load a Popolo file that doesn't have every Popolo class we support present. 777eeff makes it so that these aren't mandatory and an empty array is returned for any classes that have no data instead.

We needed this for loading `vote_events` data which don't have things like `people` present.

ad3c46d is a refactor to DRY up the initialization code for the collection classes. I'm less happy with this, specifically the class name generation code, so if you only want to cherry pick the first commit that's cool. Relates to #13.
