### PR TITLE
Add Finders

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,28 @@ person.id # => "e3aab23e-a883-4763-be0d-92e5936024e2"
 person.name # => "Aaltonen Carina"
 person.image # => "http://www.lagtinget.ax/files/aaltonen_carina.jpg"
 person.wikidata # => "Q4934081"
+```
 
+You can also find individual records or collections based on their attributes:
+
+```ruby
 popolo.persons.find_by(name: "Aaltonen Carina", wikidata: "Q4934081")
+    # => #<Everypolitician::Popolo::Person:0x0000000237dfc8
+    #      @document={:id=>"0c705344-23aa-4fa2-9391-af41c1c775b7",
+    #                 :identifiers=>[{:identifier=>"Q4934081", :scheme=>"wikidata"}],
+    #                 :name=>"Aaltonen Carina"}>
+
+popolo.organizations.where(classification: "party")
+    # => [
+    #      <Everypolitician::Popolo::Organization:0x000000035779e0
+    #       @document={:classification=>"party",
+    #                  :id=>"123",
+    #                  :name=>"Sunripe Tomato Party"}>,
+    #      <Everypolitician::Popolo::Organization:0x000000035779e1
+    #       @document={:classification=>"party",
+    #                  :id=>"456",
+    #                  :name=>"The Greens"}>
+    #    ]
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ person.id # => "e3aab23e-a883-4763-be0d-92e5936024e2"
 person.name # => "Aaltonen Carina"
 person.image # => "http://www.lagtinget.ax/files/aaltonen_carina.jpg"
 person.wikidata # => "Q4934081"
+
+popolo.persons.find_by(name: "Aaltonen Carina", wikidata: "Q4934081")
 ```
 
 ## Development

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -19,11 +19,7 @@ module Everypolitician
       end
 
       def find_by(attributes = {})
-        find do |object|
-          !attributes.collect do |k,v|
-            object.send(k) == v
-          end.include?(false)
-        end
+        where(attributes).first
       end
 
       def where(attributes = {})

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -26,6 +26,14 @@ module Everypolitician
         end
       end
 
+      def where(attributes = {})
+        find_all do |object|
+          !attributes.collect do |k,v|
+            object.send(k) == v
+          end.include?(false)
+        end
+      end
+
       private
 
       # TODO: This feels pretty nasty, is there a better way of working out the

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -24,9 +24,7 @@ module Everypolitician
 
       def where(attributes = {})
         find_all do |object|
-          !attributes.collect do |k,v|
-            object.send(k) == v
-          end.include?(false)
+          attributes.all? { |k, v| object.send(k) == v }
         end
       end
 

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -18,6 +18,14 @@ module Everypolitician
         documents.reject { |d| other_ids.include?(d.id) }
       end
 
+      def find_by(attributes = {})
+        find do |object|
+          !attributes.collect do |k,v|
+            object.send(k) == v
+          end.include?(false)
+        end
+      end
+
       private
 
       # TODO: This feels pretty nasty, is there a better way of working out the

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -26,4 +26,42 @@ class Everypolitician::CollectionTest < Minitest::Test
     assert_equal popolo.organizations.find_by(id: "foo_corp", name: "Foo Corp").id, "foo_corp"
     assert_equal popolo.organizations.find_by(id: "foo_corp", name: "Foo Corp").name, "Foo Corp"
   end
+
+  def test_where_finding_multiple_parties
+    popolo = Everypolitician::Popolo::JSON.new(
+      organizations: [
+        { id: "representatives", name: "House o' Representin'", classification: "legislature" },
+        { id: "tomato", name: "Sunripe Tomato Party", classification: "party" },
+        { id: "greens", name: "The Greens", classification: "party" }
+      ]
+    )
+
+    assert_equal popolo.organizations.where(classification: "party").count, 2
+    assert_equal popolo.organizations.where(classification: "party").first.name, "Sunripe Tomato Party"
+  end
+
+  def test_where_finding_no_items
+    popolo = Everypolitician::Popolo::JSON.new(
+      organizations: [
+        { id: "representatives", name: "House o' Representin'", classification: "legislature" },
+        { id: "tomato", name: "Sunripe Tomato Party", classification: "party" },
+        { id: "greens", name: "The Greens", classification: "party" }
+      ]
+    )
+
+    assert_equal popolo.organizations.where(classification: "business"), []
+  end
+
+  def test_where_finding_by_multiple_attributes
+    popolo = Everypolitician::Popolo::JSON.new(
+      organizations: [
+        { id: "representatives", name: "House o' Representin'", classification: "legislature" },
+        { id: "tomato", name: "Sunripe Tomato Party", classification: "party" },
+        { id: "greens", name: "The Greens", classification: "party" }
+      ]
+    )
+
+    assert_equal popolo.organizations.where(classification: "party", name: "The Greens").count, 1
+    assert_equal popolo.organizations.where(classification: "party", name: "The Greens").first.id, "greens"
+  end
 end

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class Everypolitician::CollectionTest < Minitest::Test
+  def test_find_by_finding_a_person
+    popolo = Everypolitician::Popolo::JSON.new(
+      persons: [{ id: "abc", name: "Jane" }, { id: "123", name: "Bob" }]
+    )
+
+    assert_equal popolo.persons.find_by(id: "123").id, "123"
+    assert_equal popolo.persons.find_by(id: "123").name, "Bob"
+  end
+
+  def test_find_by_finding_no_item
+    popolo = Everypolitician::Popolo::JSON.new(
+      persons: [{ id: "abc", name: "Jane" }, { id: "123", name: "Bob" }]
+    )
+
+    assert_equal popolo.persons.find_by(id: "blah"), nil
+  end
+
+  def test_find_by_finding_an_organization_by_multiple_attributes
+    popolo = Everypolitician::Popolo::JSON.new(
+      organizations: [{ id: "foo_corp", name: "Foo Corp" }, { id: "bar_corp", name: "Bar Corp" }]
+    )
+
+    assert_equal popolo.organizations.find_by(id: "foo_corp", name: "Foo Corp").id, "foo_corp"
+    assert_equal popolo.organizations.find_by(id: "foo_corp", name: "Foo Corp").name, "Foo Corp"
+  end
+end


### PR DESCRIPTION
This adds `find_by` and `where` finders to the collection class to allow you to look up items.

It was extracted after writing a bunch of [real world specific finders](https://github.com/openaustralia/planningalerts/blob/cf310a9821b3918a4ef3f4e98b2be9a229f5661a/lib/planning_alerts_popolo.rb) to see what we needed.
