### PR TITLE
Don't require pry as it's only available in development

### DIFF
--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module Everypolitician
   module Popolo
     class Entity


### PR DESCRIPTION
It looks like this was left in during development. As the pry gem is
only installed in the development bundle this fails when this gem is
used in production.

I discovered this when trying to use it on morph.io. The buildpacks on
there run `bundle install --without development:test`... so the pry gem
isn't installed.
