### PR TITLE
Add support for popolo posts collection

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -5,6 +5,7 @@ require 'everypolitician/popolo/person'
 require 'everypolitician/popolo/organization'
 require 'everypolitician/popolo/area'
 require 'everypolitician/popolo/event'
+require 'everypolitician/popolo/post'
 require 'everypolitician/popolo/membership'
 require 'json'
 
@@ -42,6 +43,10 @@ module Everypolitician
 
       def events
         Events.new(popolo[:events])
+      end
+
+      def posts
+        Posts.new(popolo[:posts])
       end
 
       def memberships

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -42,6 +42,8 @@ module Everypolitician
           Membership
         when "Events"
           Event
+        when "Posts"
+          Post
         when "Areas"
           Area
         else

--- a/lib/everypolitician/popolo/post.rb
+++ b/lib/everypolitician/popolo/post.rb
@@ -1,0 +1,6 @@
+module Everypolitician
+  module Popolo
+    class Posts < Collection; end
+    class Post < Entity; end
+  end
+end

--- a/test/everypolitician/popolo/post_test.rb
+++ b/test/everypolitician/popolo/post_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class Everypolitician::PostTest < Minitest::Test
+  def test_reading_popolo_posts
+    popolo = Everypolitician::Popolo::JSON.new(
+      posts: [{ id: 'womens_representative', label: "Women's Representative" }]
+    )
+    post = popolo.posts.first
+
+    assert_instance_of Everypolitician::Popolo::Posts, popolo.posts
+    assert_instance_of Everypolitician::Popolo::Post, post
+  end
+
+  def test_no_posts_in_popolo_data
+    popolo = Everypolitician::Popolo::JSON.new(other_data: [{ id: '123', foo: 'Bar' }])
+    assert_equal true, popolo.posts.none?
+  end
+
+  def test_accessing_post_properties
+    popolo = Everypolitician::Popolo::JSON.new(
+      posts: [{ id: 'womens_representative', label: "Women's Representative" }]
+    )
+    post = popolo.posts.first
+
+    assert_equal 'womens_representative', post.id
+    assert_equal "Women's Representative", post.label
+  end
+end


### PR DESCRIPTION
Uganda has recently added a posts collection for people that hold a post
but aren't necessarily MPs tied to an area, e.g. Women's
Representatives, which is a post a lot of African countries have.

Fixes #25 
