### PR TITLE
Add post label to list of known attributes

### DIFF
--- a/lib/everypolitician/popolo/post.rb
+++ b/lib/everypolitician/popolo/post.rb
@@ -1,6 +1,8 @@
 module Everypolitician
   module Popolo
     class Posts < Collection; end
-    class Post < Entity; end
+    class Post < Entity
+      attr_reader :label
+    end
   end
 end

--- a/test/everypolitician/popolo/post_test.rb
+++ b/test/everypolitician/popolo/post_test.rb
@@ -25,4 +25,13 @@ class Everypolitician::PostTest < Minitest::Test
     assert_equal 'womens_representative', post.id
     assert_equal "Women's Representative", post.label
   end
+
+  def test_it_returns_nil_for_missing_label
+    popolo = Everypolitician::Popolo::JSON.new(
+      posts: [{ id: 'womens_representative' }]
+    )
+    post = popolo.posts.first
+
+    assert_nil post.label
+  end
 end


### PR DESCRIPTION
This stops things from breaking if `Post#label` is called on a post
without a label.

Part of #25 
