### PR TITLE
Add start/end_date methods to Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.2] - 2016-06-06
+
+### Fixed
+
+- Added missing attribute definition for `Event#start_date` and
+  `Event#end_date`
+
 ## [0.3.1] - 2016-05-04
 
 ### Fixed

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,6 +1,8 @@
 module Everypolitician
   module Popolo
     class Events < Collection; end
-    class Event < Entity; end
+    class Event < Entity; 
+      attr_accessor :start_date, :end_date
+    end
   end
 end

--- a/lib/everypolitician/popolo/version.rb
+++ b/lib/everypolitician/popolo/version.rb
@@ -1,5 +1,5 @@
 module Everypolitician
   module Popolo
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -25,5 +25,6 @@ class Everypolitician::EventTest < Minitest::Test
     assert_equal 'term/8', event.id
     assert_equal '8th Verkhovna Rada', event.name
     assert_equal '2014-11-27', event.start_date
+    assert_nil event.end_date
   end
 end


### PR DESCRIPTION
If an Event has no end date set, ensure that the `end_date` method returns
`nil`, rather than throwing an `undefined method 'end_date'` exception.
