### PR TITLE
Release 0.4.0: Organization.wikidata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.0] - 2016-07-04
+
+### Added
+
+- Added `Organization#wikidata`
+
 ## [0.3.2] - 2016-06-06
 
 ### Fixed

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -30,6 +30,9 @@ module Everypolitician
       end
       alias eql? ==
 
+      def identifier(scheme)
+        identifiers.find(->{{}}) { |i| i[:scheme] == scheme }[:identifier]
+      end
     end
   end
 end

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -2,7 +2,7 @@ module Everypolitician
   module Popolo
     class Organizations < Collection; end
 
-    class Organization < Entity; 
+    class Organization < Entity
       def wikidata
         identifier('wikidata')
       end

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -1,6 +1,11 @@
 module Everypolitician
   module Popolo
     class Organizations < Collection; end
-    class Organization < Entity; end
+
+    class Organization < Entity; 
+      def wikidata
+        identifier('wikidata')
+      end
+    end
   end
 end

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -19,11 +19,6 @@ module Everypolitician
         document.fetch(:contact_details, [])
       end
 
-
-      def identifier(scheme)
-        identifiers.find(->{{}}) { |i| i[:scheme] == scheme }[:identifier]
-      end
-
       def contact(type)
         contact_details.find(->{{}}) { |i| i[:type] == type }[:value]
       end

--- a/lib/everypolitician/popolo/version.rb
+++ b/lib/everypolitician/popolo/version.rb
@@ -1,5 +1,5 @@
 module Everypolitician
   module Popolo
-    VERSION = '0.3.2'
+    VERSION = '0.4.0'
   end
 end

--- a/test/everypolitician/popolo/organization_test.rb
+++ b/test/everypolitician/popolo/organization_test.rb
@@ -40,6 +40,6 @@ class Everypolitician::OrganizationTest < Minitest::Test
       name: 'ACME', 
       identifiers: [{identifier: "Q288523", scheme: "wikidata"}],
     )
-    assert_equal org.wikidata, 'Q288523'
+    assert_equal 'Q288523', org.wikidata
   end
 end

--- a/test/everypolitician/popolo/organization_test.rb
+++ b/test/everypolitician/popolo/organization_test.rb
@@ -33,4 +33,13 @@ class Everypolitician::OrganizationTest < Minitest::Test
     just_org_1 = Everypolitician::Popolo::Organizations.new([org1])
     assert_equal [Everypolitician::Popolo::Organization.new(org2)], all_orgs - just_org_1
   end
+
+  def test_organization_wikidata
+    org = Everypolitician::Popolo::Organization.new(
+      id: 'abc', 
+      name: 'ACME', 
+      identifiers: [{identifier: "Q288523", scheme: "wikidata"}],
+    )
+    assert_equal org.wikidata, 'Q288523'
+  end
 end


### PR DESCRIPTION
Promote `identifer` onto Entity, and use it to provide a `wikidata` method on an Organization, parallel to the one on Person.
