### PR TITLE
Equality should check class as well as id

### DIFF
--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -26,8 +26,7 @@ module Everypolitician
       end
 
       def ==(other)
-        return false unless other.instance_of?(self.class) 
-        id == other.id
+        self.class == other.class && id == other.id
       end
       alias eql? ==
 

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -26,6 +26,7 @@ module Everypolitician
       end
 
       def ==(other)
+        return false unless other.instance_of?(self.class) 
         id == other.id
       end
       alias eql? ==

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -155,6 +155,13 @@ class Everypolitician::PersonTest < Minitest::Test
     person2 = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob', gender: 'male')
     organization = Everypolitician::Popolo::Organization.new(id: '123')
     assert_equal person1, person2
+  end
+
+  def test_person_equality_based_on_class
+    person1 = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob')
+    person2 = Everypolitician::Popolo::Person.new(id: '123', name: 'Babs')
+    organization = Everypolitician::Popolo::Organization.new(id: '123')
+    assert_equal person1, person2
     refute_equal person1, organization
   end
 

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -155,7 +155,7 @@ class Everypolitician::PersonTest < Minitest::Test
     person2 = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob', gender: 'male')
     organization = Everypolitician::Popolo::Organization.new(id: '123')
     assert_equal person1, person2
-    assert_equal person1, organization
+    refute_equal person1, organization
   end
 
   def test_persons_subtraction

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -153,7 +153,9 @@ class Everypolitician::PersonTest < Minitest::Test
   def test_person_equality_based_on_id
     person1 = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob')
     person2 = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob', gender: 'male')
+    organization = Everypolitician::Popolo::Organization.new(id: '123')
     assert_equal person1, person2
+    assert_equal person1, organization
   end
 
   def test_persons_subtraction

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -153,7 +153,6 @@ class Everypolitician::PersonTest < Minitest::Test
   def test_person_equality_based_on_id
     person1 = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob')
     person2 = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob', gender: 'male')
-    organization = Everypolitician::Popolo::Organization.new(id: '123')
     assert_equal person1, person2
   end
 

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -159,9 +159,7 @@ class Everypolitician::PersonTest < Minitest::Test
 
   def test_person_equality_based_on_class
     person1 = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob')
-    person2 = Everypolitician::Popolo::Person.new(id: '123', name: 'Babs')
     organization = Everypolitician::Popolo::Organization.new(id: '123')
-    assert_equal person1, person2
     refute_equal person1, organization
   end
 


### PR DESCRIPTION
Equality should check class as well as id #24

@tmtmtmtm Amended == method in Entity class. Returns false if objects do not share the same class.
