### PR TITLE
Add methods for accessing legislative periods

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -56,10 +56,12 @@ module Everypolitician
       def legislative_periods
         events.where(classification: 'legislative period').sort_by(&:start_date)
       end
+      alias_method :terms, :legislative_periods
 
       def current_legislative_period
         legislative_periods[-1]
       end
+      alias_method :current_term, :current_legislative_period
     end
   end
 end

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -52,6 +52,14 @@ module Everypolitician
       def memberships
         Memberships.new(popolo[:memberships])
       end
+
+      def legislative_periods
+        events.where(classification: 'legislative period').sort_by(&:start_date)
+      end
+
+      def current_legislative_period
+        legislative_periods[-1]
+      end
     end
   end
 end

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -59,7 +59,7 @@ module Everypolitician
       alias_method :terms, :legislative_periods
 
       def current_legislative_period
-        legislative_periods[-1]
+        legislative_periods.last
       end
       alias_method :current_term, :current_legislative_period
     end

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -4,11 +4,14 @@ class Everypolitician::Popolo::JsonTest < Minitest::Test
   def test_legislative_periods
     popolo_json = Everypolitician::Popolo::JSON.new(
       events: [
+        { name: 'Election 1', classification: 'general election', start_date: '2014-01-01' },
         { name: 'Term 2', classification: 'legislative period', start_date: '2015-01-01' },
         { name: 'Term 1', classification: 'legislative period', start_date: '2010-01-01' },
       ],
     )
     assert_equal 2, popolo_json.legislative_periods.size
+    assert_equal 2, popolo_json.terms.size
     assert_equal 'Term 2', popolo_json.current_legislative_period.name
+    assert_equal 'Term 2', popolo_json.current_term.name
   end
 end

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -13,11 +13,13 @@ class Everypolitician::Popolo::JsonTest < Minitest::Test
 
   def test_legislative_periods_ignores_other_event_types
     assert_equal 2, popolo_json.legislative_periods.size
-    assert_equal 2, popolo_json.terms.size
   end
 
   def test_current_legislative_period_returns_correct_term
     assert_equal 'Term 2', popolo_json.current_legislative_period.name
-    assert_equal 'Term 2', popolo_json.current_term.name
+  end
+
+  def test_that_terms_returns_the_same_as_legislative_periods
+    assert_equal popolo_json.terms, popolo_json.legislative_periods
   end
 end

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -1,16 +1,22 @@
 require 'test_helper'
 
 class Everypolitician::Popolo::JsonTest < Minitest::Test
-  def test_legislative_periods
-    popolo_json = Everypolitician::Popolo::JSON.new(
+  def popolo_json
+    @popolo_json ||= Everypolitician::Popolo::JSON.new(
       events: [
         { name: 'Election 1', classification: 'general election', start_date: '2014-01-01' },
         { name: 'Term 2', classification: 'legislative period', start_date: '2015-01-01' },
         { name: 'Term 1', classification: 'legislative period', start_date: '2010-01-01' },
       ],
     )
+  end
+
+  def test_legislative_periods_ignores_other_event_types
     assert_equal 2, popolo_json.legislative_periods.size
     assert_equal 2, popolo_json.terms.size
+  end
+
+  def test_current_legislative_period_returns_correct_term
     assert_equal 'Term 2', popolo_json.current_legislative_period.name
     assert_equal 'Term 2', popolo_json.current_term.name
   end

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class Everypolitician::Popolo::JsonTest < Minitest::Test
+  def test_legislative_periods
+    popolo_json = Everypolitician::Popolo::JSON.new(
+      events: [
+        { name: 'Term 2', classification: 'legislative period', start_date: '2015-01-01' },
+        { name: 'Term 1', classification: 'legislative period', start_date: '2010-01-01' },
+      ],
+    )
+    assert_equal 2, popolo_json.legislative_periods.size
+    assert_equal 'Term 2', popolo_json.current_legislative_period.name
+  end
+end

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -22,4 +22,8 @@ class Everypolitician::Popolo::JsonTest < Minitest::Test
   def test_that_terms_returns_the_same_as_legislative_periods
     assert_equal popolo_json.terms, popolo_json.legislative_periods
   end
+
+  def test_current_term_returns_the_same_as_current_legislative_period
+    assert_equal popolo_json.current_term, popolo_json.current_legislative_period
+  end
 end


### PR DESCRIPTION
This adds a method to return the events that have `classification` of `legislative period`. It also adds a `current_legislative_period` (aliases to `current_term`) method, which will return the most recent term in the popolo (though it may not actually be the latest term).

Fixes https://github.com/everypolitician/everypolitician-popolo/issues/35
