### PR TITLE
Add a `link(type)` method

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,15 +5,3 @@
 # one by one as the offenses are removed from the code base.
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
-
-# Offense count: 2
-# Configuration parameters: AllowSafeAssignment.
-Lint/AssignmentInCondition:
-  Exclude:
-    - 'lib/everypolitician/popolo/person.rb'
-
-# Offense count: 1
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
-  Exclude:
-    - 'lib/everypolitician/popolo/person.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.0] - 2016-08-01
+
+### Added
+
+- Added `Person#link(type)`
+
 ## [0.4.0] - 2016-07-04
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in everypolitician-popolo.gemspec
 gemspec
 
-gem 'rubocop'

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -11,6 +11,10 @@ module Everypolitician
         document.fetch(:links, [])
       end
 
+      def link(type)
+        links.find(-> { {} }) { |i| i[:note] == type }[:url]
+      end
+
       def identifiers
         document.fetch(:identifiers, [])
       end
@@ -45,8 +49,7 @@ module Everypolitician
       end
 
       def facebook
-        facebook_link = links.find { |d| d[:note] == 'facebook' }
-        facebook_link[:url] if facebook_link
+        link('facebook')
       end
 
       def wikidata

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -36,16 +36,7 @@ module Everypolitician
       end
 
       def twitter
-        if key?(:contact_details)
-          if twitter_contact = self[:contact_details].find { |d| d[:type] == 'twitter' }
-            return twitter_contact[:value].strip
-          end
-        end
-        if key?(:links)
-          if twitter_link = self[:links].find { |d| d[:note][/twitter/i] }
-            return twitter_link[:url].strip
-          end
-        end
+        contact('twitter') || link('twitter')
       end
 
       def facebook

--- a/lib/everypolitician/popolo/version.rb
+++ b/lib/everypolitician/popolo/version.rb
@@ -1,5 +1,5 @@
 module Everypolitician
   module Popolo
-    VERSION = '0.4.0'.freeze
+    VERSION = '0.5.0'.freeze
   end
 end


### PR DESCRIPTION
Don't force people to go digging in "links" themselves — provide them a
handy lookup function, and then use it to simplify `facebook` and `twitter` lookups.

Also closes https://github.com/everypolitician/everypolitician-popolo/issues/43 
