### PR TITLE
Revert "Release 0.6.0: Remove leading components from IDs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,6 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.6.0] - 2016-08-27
-
-### Changed
-
-- the `id` for an Entity will now strip any prefix (e.g. "party/abc"
-  will now be simply "abc")
-
 ## [0.5.0] - 2016-08-01
 
 ### Added
@@ -59,8 +52,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [0.2.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.2.0...v0.3.0
-[0.3.1]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.3.0...v0.3.1
-[0.3.2]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.3.1...v0.3.2
-[0.4.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.3.0...v0.4.0
-[0.5.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.4.0...v0.5.0
-[0.6.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.5.0...v0.6.0
+[0.3.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.3.0...v0.3.1

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -1,7 +1,7 @@
 module Everypolitician
   module Popolo
     class Entity
-      attr_writer :id
+      attr_accessor :id
       attr_reader :document
       attr_reader :popolo
 
@@ -30,10 +30,6 @@ module Everypolitician
         self.class == other.class && id == other.id
       end
       alias eql? ==
-
-      def id
-        @id.to_s.split('/').last
-      end
 
       def identifier(scheme)
         identifiers.find(-> { {} }) { |i| i[:scheme] == scheme }[:identifier]

--- a/lib/everypolitician/popolo/version.rb
+++ b/lib/everypolitician/popolo/version.rb
@@ -1,5 +1,5 @@
 module Everypolitician
   module Popolo
-    VERSION = '0.6.0'.freeze
+    VERSION = '0.5.0'.freeze
   end
 end

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -22,7 +22,7 @@ class EventTest < Minitest::Test
     )
     event = popolo.events.first
 
-    assert_equal '8', event.id
+    assert_equal 'term/8', event.id
     assert_equal '8th Verkhovna Rada', event.name
     assert_equal '2014-11-27', event.start_date
     assert_nil event.end_date

--- a/test/everypolitician/popolo/organization_test.rb
+++ b/test/everypolitician/popolo/organization_test.rb
@@ -21,7 +21,7 @@ class OrganizationTest < Minitest::Test
   end
 
   def test_organization_equality_based_on_id
-    org1 = Everypolitician::Popolo::Organization.new(id: 'org/abc', name: 'ACME')
+    org1 = Everypolitician::Popolo::Organization.new(id: 'abc', name: 'ACME')
     org2 = Everypolitician::Popolo::Organization.new(id: 'abc', name: 'ACME')
     assert_equal org1, org2
   end

--- a/test/everypolitician/popolo_test.rb
+++ b/test/everypolitician/popolo_test.rb
@@ -17,7 +17,7 @@ class PopoloTest < Minitest::Test
     popolo = Everypolitician::Popolo.read('test/fixtures/ep-popolo-v1.0.json')
     assert_equal 1, popolo.persons.count
     person = popolo.persons.first
-    assert_equal '123', person.id
+    assert_equal 'person/123', person.id
     assert_equal 'Bob Smith', person.name
   end
 end


### PR DESCRIPTION
Reverts everypolitician/everypolitician-popolo#48 — this breaks badly, as the referenced IDs in memberships will now be of a different form to the actual IDs.
