### PR TITLE
fix the incorrect details on everypolitician-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ so you don't need to handle JSON files at all. The data the gem returns is in
 ```ruby
 require 'everypolitician'
 
-australia = Everypolitician.country('Australia')
+australia = Everypolitician::Index.new.country('Australia')
 australia.code # => "AU"
 senate = australia.legislature('Senate')
 senate.persons.find_by(name: "Aden Ridgeway")

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In the example above, the Popolo data comes from a downloaded file
 [EveryPolitician website](http://everypolitician.org).
 But your Ruby application can also interact directly with the EveryPolitician
 data using the
-[everypolitician-ruby gem](http://github.com/everypolitician/everypolitcian-ruby),
+[everypolitician-ruby gem](http://github.com/everypolitician/everypolitician-ruby),
 so you don't need to handle JSON files at all. The data the gem returns is in
 `Everypolitician::Popolo` format.
 


### PR DESCRIPTION
- fixes link (mis-spelt `everypolitician`)
- now uses `Index.new` in the get-a-country example

Close #51 
