### PR TITLE
Add real methods to Organisation class

### DIFF
--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -1,8 +1,32 @@
 module Everypolitician
   module Popolo
     class Organization < Entity
+      attr_reader :classification,
+                  :identifiers,
+                  :image,
+                  :links,
+                  :name,
+                  :other_names,
+                  :seats
+
+      def initializer(p, _popolo = nil)
+        @classification = p[:classification]
+        @identifiers = p[:identifiers]
+        @image = p[:image]
+        @links = p[:links]
+        @name = p[:name]
+        @other_names = p[:other_names]
+        @seats = p[:seats]
+      end
+
       def wikidata
         identifier('wikidata')
+      end
+
+      private
+
+      def identifier(scheme_name)
+        identifiers.find { |i| i[:scheme] == scheme_name }[:identifier] rescue nil
       end
     end
 

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -1,22 +1,36 @@
 module Everypolitician
   module Popolo
     class Organization < Entity
-      attr_reader :classification,
-                  :identifiers,
-                  :image,
-                  :links,
-                  :name,
-                  :other_names,
-                  :seats
+      def initializer(document)
+        @document = document
+      end
 
-      def initializer(p, _popolo = nil)
-        @classification = p[:classification]
-        @identifiers = p[:identifiers]
-        @image = p[:image]
-        @links = p[:links]
-        @name = p[:name]
-        @other_names = p[:other_names]
-        @seats = p[:seats]
+      def classification
+        document[:classification]
+      end
+
+      def identifiers
+        document[:identifiers]
+      end
+
+      def image
+        document[:image]
+      end
+
+      def links
+        document[:links]
+      end
+
+      def name
+        document[:name]
+      end
+
+      def other_names
+        document[:other_names]
+      end
+
+      def seats
+        document[:seats]
       end
 
       def wikidata
@@ -24,6 +38,8 @@ module Everypolitician
       end
 
       private
+
+      attr_reader :document
 
       def identifier(scheme_name)
         identifiers.find { |i| i[:scheme] == scheme_name }[:identifier] rescue nil

--- a/test/everypolitician/popolo/organization_test.rb
+++ b/test/everypolitician/popolo/organization_test.rb
@@ -1,22 +1,20 @@
 require 'test_helper'
 
 class OrganizationTest < Minitest::Test
-  def test_popolo
-    Everypolitician::Popolo::JSON.new(organizations: [{ id:             '123',
-                                                        name:           'ACME',
-                                                        classification: 'party',
-                                                        identifier:     'Q288523',
-                                                        image:          'http://www.parlamentra.org/upload/iblock/09f/avidzba-f.jpg',
-                                                        links:          [{ url: 'http://www.test.com' }],
-                                                        other_names:    [{ name: 'ACME Inc' }],
-                                                        identifiers:    [{ identifier: 'Q288523', scheme: 'wikidata' }],
-                                                        seats:          42, },])
+  def organizations
+    @organizations ||= Everypolitician::Popolo.read('test/fixtures/turkey-ep-popolo-v1.0.json').organizations
   end
 
-  def test_reading_popolo_organizations
-    popolo = Everypolitician::Popolo::JSON.new(organizations: [{ id: '123', name: 'ACME' }])
-    assert_instance_of Everypolitician::Popolo::Organizations, popolo.organizations
-    organization = popolo.organizations.first
+  def organization
+    @organization ||= organizations.select { |o| o.id == 'MHP' }.first
+  end
+
+  def organization_with_seats
+    @organization_with_seats ||= organizations.select { |o| o.classification == 'legislature' }.first
+  end
+
+  def test_reading_popolo_organizationsions
+    assert_instance_of Everypolitician::Popolo::Organizations, organizations
     assert_instance_of Everypolitician::Popolo::Organization, organization
   end
 
@@ -25,16 +23,37 @@ class OrganizationTest < Minitest::Test
     assert_equal true, popolo.organizations.none?
   end
 
-  def test_accessing_organization_properties
-    organization = test_popolo.organizations.first
-    assert_equal '123', organization.id
-    assert_equal 'ACME', organization.name
+  def test_organization_id
+    assert_equal 'MHP', organization.id
+  end
+
+  def test_organization_name
+    assert_equal 'Milliyetçi Hareket Partisi', organization.name
+  end
+
+  def test_organization_classification
     assert_equal 'party', organization.classification
-    assert_equal 'http://www.parlamentra.org/upload/iblock/09f/avidzba-f.jpg', organization.image
-    assert_equal [{ url: 'http://www.test.com' }], organization.links
-    assert_equal [{ name: 'ACME Inc' }], organization.other_names
-    assert_equal [{ identifier: 'Q288523', scheme: 'wikidata' }], organization.identifiers
-    assert_equal 42, organization.seats
+  end
+
+  def test_organization_image
+    assert_equal 'https://upload.wikimedia.org/wikipedia/commons/e/e4/Milliyetçi_Hareket_Partisi_amblemi.png', organization.image
+  end
+
+  def test_organization_links
+    assert_equal [{ note: 'website', url: 'http://www.mhp.org.tr/' }], organization.links
+  end
+
+  def test_organization_other_names
+    organization_other_names = { lang: 'bar', name: 'Pårtei då Nationalistischn Bwegung', note: 'multilingual' }
+    assert_equal organization_other_names, organization.other_names.first
+  end
+
+  def test_organization_identifiers
+    assert_equal [{ identifier: 'Q251077', scheme: 'wikidata' }], organization.identifiers
+  end
+
+  def test_organization_seats
+    assert_equal 550, organization_with_seats.seats
   end
 
   def test_organization_equality_based_on_id
@@ -52,12 +71,7 @@ class OrganizationTest < Minitest::Test
   end
 
   def test_organization_wikidata
-    org = Everypolitician::Popolo::Organization.new(
-      id:          'abc',
-      name:        'ACME',
-      identifiers: [{ identifier: 'Q288523', scheme: 'wikidata' }]
-    )
-    assert_equal 'Q288523', org.wikidata
+    assert_equal 'Q348125', organizations.first.wikidata
   end
 
   def test_organization_no_wikidata

--- a/test/everypolitician/popolo/organization_test.rb
+++ b/test/everypolitician/popolo/organization_test.rb
@@ -1,6 +1,18 @@
 require 'test_helper'
 
 class OrganizationTest < Minitest::Test
+  def test_popolo
+    Everypolitician::Popolo::JSON.new(organizations: [{ id:             '123',
+                                                        name:           'ACME',
+                                                        classification: 'party',
+                                                        identifier:     'Q288523',
+                                                        image:          'http://www.parlamentra.org/upload/iblock/09f/avidzba-f.jpg',
+                                                        links:          [{ url: 'http://www.test.com' }],
+                                                        other_names:    [{ name: 'ACME Inc' }],
+                                                        identifiers:    [{ identifier: 'Q288523', scheme: 'wikidata' }],
+                                                        seats:          42, },])
+  end
+
   def test_reading_popolo_organizations
     popolo = Everypolitician::Popolo::JSON.new(organizations: [{ id: '123', name: 'ACME' }])
     assert_instance_of Everypolitician::Popolo::Organizations, popolo.organizations
@@ -14,10 +26,15 @@ class OrganizationTest < Minitest::Test
   end
 
   def test_accessing_organization_properties
-    popolo = Everypolitician::Popolo::JSON.new(organizations: [{ id: '123', name: 'ACME' }])
-    organization = popolo.organizations.first
+    organization = test_popolo.organizations.first
     assert_equal '123', organization.id
     assert_equal 'ACME', organization.name
+    assert_equal 'party', organization.classification
+    assert_equal 'http://www.parlamentra.org/upload/iblock/09f/avidzba-f.jpg', organization.image
+    assert_equal [{ url: 'http://www.test.com' }], organization.links
+    assert_equal [{ name: 'ACME Inc' }], organization.other_names
+    assert_equal [{ identifier: 'Q288523', scheme: 'wikidata' }], organization.identifiers
+    assert_equal 42, organization.seats
   end
 
   def test_organization_equality_based_on_id


### PR DESCRIPTION
Methods are currently created dynamically by Entity initialiser. Adding the following attr_reader methods to Organization class:

Properties are set in the class initializer.

Also a private method for retrieving identifier id from identifiers given the name of the scheme.

Addresses issue: https://github.com/everypolitician/everypolitician-popolo/issues/54
