### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.6.1]
+## [0.6.1] - 2016-09-12
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.6.0] - 2016-09-03
+## [0.6.1]
+
+### Fixes
+
+- Version 0.6.0 was accidentally tagged at the wrong (broken) point in history, which included a broken fix for removing the `id` prefix from entities ([#48](https://github.com/everypolitician/everypolitician-popolo/pull/48)), but not the pull request reverting that change ([#49](https://github.com/everypolitician/everypolitician-popolo/pull/49)). 0.6.0 has been yanked from RubyGems and we recommend using version 0.6.1.
+
+## [0.6.0] (yanked from RubyGems.org) - 2016-09-03
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixes
 
-- Version 0.6.0 was accidentally tagged at the wrong (broken) point in history, which included a broken fix for removing the `id` prefix from entities ([#48](https://github.com/everypolitician/everypolitician-popolo/pull/48)), but not the pull request reverting that change ([#49](https://github.com/everypolitician/everypolitician-popolo/pull/49)). 0.6.0 has been yanked from RubyGems and we recommend using version 0.6.1.
+- Version 0.6.0 was accidentally tagged at the wrong (broken) point in history,
+  which included a broken fix for removing the `id` prefix from entities
+  ([#48](https://github.com/everypolitician/everypolitician-popolo/pull/48)),
+  but not the pull request reverting that change
+  ([#49](https://github.com/everypolitician/everypolitician-popolo/pull/49)).
+  0.6.0 has been yanked from RubyGems and we recommend using version 0.6.1.
 
 ## [0.6.0] (yanked from RubyGems.org) - 2016-09-03
 

--- a/lib/everypolitician/popolo/version.rb
+++ b/lib/everypolitician/popolo/version.rb
@@ -1,5 +1,5 @@
 module Everypolitician
   module Popolo
-    VERSION = '0.6.0'.freeze
+    VERSION = '0.6.1'.freeze
   end
 end


### PR DESCRIPTION
This release is needed because I accidentally release version 0.6.0 of the library to RubyGems at the wrong version, which included the broken fix stripping the `id` prefix (#48) but not the change reverting that fix (#49). I yanked version 0.6.0 from RubyGems less than 5 minutes after releasing it, so hopefully no one will be inconvenienced by this change.
