### PR TITLE
add an entity_class setter to the collection class

### DIFF
--- a/lib/everypolitician/popolo/area.rb
+++ b/lib/everypolitician/popolo/area.rb
@@ -1,7 +1,8 @@
 module Everypolitician
   module Popolo
+    class Area < Entity; end
+
     class Areas < Collection
     end
-    class Area < Entity; end
   end
 end

--- a/lib/everypolitician/popolo/area.rb
+++ b/lib/everypolitician/popolo/area.rb
@@ -1,6 +1,7 @@
 module Everypolitician
   module Popolo
-    class Areas < Collection; end
+    class Areas < Collection
+    end
     class Area < Entity; end
   end
 end

--- a/lib/everypolitician/popolo/area.rb
+++ b/lib/everypolitician/popolo/area.rb
@@ -3,6 +3,7 @@ module Everypolitician
     class Area < Entity; end
 
     class Areas < Collection
+      entity_class Area
     end
   end
 end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -6,8 +6,21 @@ module Everypolitician
       attr_reader :documents
       attr_reader :popolo
 
+      # set the class that represents individual items in the
+      # collection
+      def self.entity_class(entity)
+        @entity_class = entity
+      end
+
+      # we need to do this slightly awful looking thing becuase
+      # we want a class instance variable and not an instance
+      # variable
+      def entity_class
+        self.class.instance_variable_get :@entity_class
+      end
+
       def initialize(documents, popolo = nil)
-        @documents = documents ? documents.map { |p| klass.new(p, popolo) } : []
+        @documents = documents ? documents.map { |p| entity_class.new(p, popolo) } : []
         @popolo = popolo
       end
 
@@ -27,29 +40,6 @@ module Everypolitician
       def where(attributes = {})
         select do |object|
           attributes.all? { |k, v| object.send(k) == v }
-        end
-      end
-
-      private
-
-      # TODO: This feels pretty nasty, is there a better way of working out the
-      # class name?
-      def klass
-        case self.class.to_s.split('::').last
-        when 'People'
-          Person
-        when 'Organizations'
-          Organization
-        when 'Memberships'
-          Membership
-        when 'Events'
-          Event
-        when 'Posts'
-          Post
-        when 'Areas'
-          Area
-        else
-          raise "Unknown class: #{self.class}"
         end
       end
     end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -8,19 +8,12 @@ module Everypolitician
 
       # set the class that represents individual items in the
       # collection
-      def self.entity_class(entity)
-        @entity_class = entity
-      end
-
-      # we need to do this slightly awful looking thing becuase
-      # we want a class instance variable and not an instance
-      # variable
-      def entity_class
-        self.class.instance_variable_get :@entity_class
+      def self.entity_class(entity = nil)
+        @entity_class ||= entity
       end
 
       def initialize(documents, popolo = nil)
-        @documents = documents ? documents.map { |p| entity_class.new(p, popolo) } : []
+        @documents = documents ? documents.map { |p| self.class.entity_class.new(p, popolo) } : []
         @popolo = popolo
       end
 

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,6 +1,8 @@
 module Everypolitician
   module Popolo
-    class Events < Collection; end
+    class Events < Collection
+    end
+
     class Event < Entity
       attr_accessor :start_date, :end_date
     end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,10 +1,10 @@
 module Everypolitician
   module Popolo
-    class Events < Collection
-    end
-
     class Event < Entity
       attr_accessor :start_date, :end_date
+    end
+
+    class Events < Collection
     end
   end
 end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -5,6 +5,7 @@ module Everypolitician
     end
 
     class Events < Collection
+      entity_class Event
     end
   end
 end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -9,6 +9,7 @@ module Everypolitician
     end
 
     class Memberships < Collection
+      entity_class Membership
     end
   end
 end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -1,14 +1,14 @@
 module Everypolitician
   module Popolo
-    class Memberships < Collection
-    end
-
     class Membership < Entity
       attr_accessor :person_id, :on_behalf_of_id, :organization_id, :area_id, :role, :start_date, :end_date
 
       def person
         popolo.persons.find_by(id: person_id)
       end
+    end
+
+    class Memberships < Collection
     end
   end
 end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -1,6 +1,7 @@
 module Everypolitician
   module Popolo
-    class Memberships < Collection; end
+    class Memberships < Collection
+    end
 
     class Membership < Entity
       attr_accessor :person_id, :on_behalf_of_id, :organization_id, :area_id, :role, :start_date, :end_date

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -1,6 +1,7 @@
 module Everypolitician
   module Popolo
-    class Organizations < Collection; end
+    class Organizations < Collection
+    end
 
     class Organization < Entity
       def wikidata

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -1,12 +1,12 @@
 module Everypolitician
   module Popolo
-    class Organizations < Collection
-    end
-
     class Organization < Entity
       def wikidata
         identifier('wikidata')
       end
+    end
+
+    class Organizations < Collection
     end
   end
 end

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -7,6 +7,7 @@ module Everypolitician
     end
 
     class Organizations < Collection
+      entity_class Organization
     end
   end
 end

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -1,8 +1,5 @@
 module Everypolitician
   module Popolo
-    class People < Collection
-    end
-
     class Person < Entity
       class Error < StandardError; end
 
@@ -63,6 +60,9 @@ module Everypolitician
       def memberships
         popolo.memberships.where(person_id: id)
       end
+    end
+
+    class People < Collection
     end
   end
 end

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -63,6 +63,7 @@ module Everypolitician
     end
 
     class People < Collection
+      entity_class Person
     end
   end
 end

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -1,6 +1,7 @@
 module Everypolitician
   module Popolo
-    class People < Collection; end
+    class People < Collection
+    end
 
     class Person < Entity
       class Error < StandardError; end

--- a/lib/everypolitician/popolo/post.rb
+++ b/lib/everypolitician/popolo/post.rb
@@ -1,10 +1,10 @@
 module Everypolitician
   module Popolo
-    class Posts < Collection
-    end
-
     class Post < Entity
       attr_reader :label
+    end
+
+    class Posts < Collection
     end
   end
 end

--- a/lib/everypolitician/popolo/post.rb
+++ b/lib/everypolitician/popolo/post.rb
@@ -5,6 +5,7 @@ module Everypolitician
     end
 
     class Posts < Collection
+      entity_class Post
     end
   end
 end

--- a/lib/everypolitician/popolo/post.rb
+++ b/lib/everypolitician/popolo/post.rb
@@ -1,6 +1,8 @@
 module Everypolitician
   module Popolo
-    class Posts < Collection; end
+    class Posts < Collection
+    end
+
     class Post < Entity
       attr_reader :label
     end


### PR DESCRIPTION
This means we can declare the class to use for individial items in a
collection in the subclass of Collection rather than working it out at
run time in the Collection class.

Note that we have to move the defintion of the Collection subclasses to
after the definition of the Item classes otherwise the Item classes
aren't know when we try to use them for entity_class.

Fixes #37
