### PR TITLE
Ignore Rubocop base config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.rubocop-https---raw-githubusercontent-com-everypolitician-everypolitician-data-master--rubocop-base-yml


### PR DESCRIPTION
This config file is a project specific artifact that we want to ignore, so it should live in the project's `.gitignore`.
