### PR TITLE
build search indexes the first time we try to look something up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.0] - 2016-09-26
+
+### Added
+
+- Property lookups are now cached the first time they are used so
+  multiple searches on the same property should be much quicker,
+  especially on large data sets.
+
 ## [0.6.1] - 2016-09-12
 
 ### Fixes
@@ -75,3 +83,4 @@ exist, rather than blowing up.
 [0.4.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.3.0...v0.4.0
 [0.5.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.4.0...v0.5.0
 [0.6.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.5.0...v0.6.0
+[0.7.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.6.0...v0.7.0

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -31,15 +31,13 @@ module Everypolitician
       end
 
       def where(attributes = {})
-        index_attributes(attributes)
-        attributes.map { |k, v| @indexes[k.to_sym][v] }.reduce(:&) || []
+        attributes.map { |k, v| index_for(k.to_sym)[v] }.reduce(:&) || []
       end
 
-      def index_attributes(attributes = {})
-        @indexes ||= {}
-        attributes.keys.each do |k|
-          @indexes[k] ||= group_by(&:"#{k}")
-        end
+      private
+
+      def index_for(attr)
+        (@indexes ||= {}).fetch(attr) { |k| @indexes[k] = group_by(&attr) }
       end
     end
   end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -31,8 +31,14 @@ module Everypolitician
       end
 
       def where(attributes = {})
-        select do |object|
-          attributes.all? { |k, v| object.send(k) == v }
+        index_attributes(attributes)
+        attributes.keys.map { |k| @indexes[k.to_sym][attributes[k]] }.reduce(:&) || []
+      end
+
+      def index_attributes(attributes = {})
+        @indexes ||= {}
+        attributes.keys.each do |k|
+          @indexes[k] ||= group_by(&:"#{k}")
         end
       end
     end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -15,6 +15,7 @@ module Everypolitician
       def initialize(documents, popolo = nil)
         @documents = documents ? documents.map { |p| self.class.entity_class.new(p, popolo) } : []
         @popolo = popolo
+        @indexes = {}
       end
 
       def each(&block)
@@ -37,7 +38,7 @@ module Everypolitician
       private
 
       def index_for(attr)
-        (@indexes ||= {}).fetch(attr) { |k| @indexes[k] = group_by(&attr) }
+        @indexes[attr] ||= group_by(&attr)
       end
     end
   end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -32,7 +32,7 @@ module Everypolitician
 
       def where(attributes = {})
         index_attributes(attributes)
-        attributes.keys.map { |k| @indexes[k.to_sym][attributes[k]] }.reduce(:&) || []
+        attributes.map { |k, v| @indexes[k.to_sym][v] }.reduce(:&) || []
       end
 
       def index_attributes(attributes = {})

--- a/lib/everypolitician/popolo/version.rb
+++ b/lib/everypolitician/popolo/version.rb
@@ -1,5 +1,5 @@
 module Everypolitician
   module Popolo
-    VERSION = '0.6.1'.freeze
+    VERSION = '0.7.0'.freeze
   end
 end


### PR DESCRIPTION
This means that the first time round things will be slower but it should
make things faster on subsequent lookups. Note that we build the indexes
on properties as they are requested rather than build them all in
advance.

Fixes #64
