### PR TITLE
memoize parsed json when it's created

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -30,27 +30,27 @@ module Everypolitician
       end
 
       def persons
-        People.new(popolo[:persons], self)
+        @persons ||= People.new(popolo[:persons], self)
       end
 
       def organizations
-        Organizations.new(popolo[:organizations], self)
+        @organizations ||= Organizations.new(popolo[:organizations], self)
       end
 
       def areas
-        Areas.new(popolo[:areas], self)
+        @areas ||= Areas.new(popolo[:areas], self)
       end
 
       def events
-        Events.new(popolo[:events], self)
+        @events ||= Events.new(popolo[:events], self)
       end
 
       def posts
-        Posts.new(popolo[:posts], self)
+        @posts ||= Posts.new(popolo[:posts], self)
       end
 
       def memberships
-        Memberships.new(popolo[:memberships], self)
+        @memberships ||= Memberships.new(popolo[:memberships], self)
       end
 
       def legislative_periods


### PR DESCRIPTION
This is so that we retain the indexes of properties across calls
to popolo.persons etc and hence the lookup speed benefits.

This is mostly to make https://github.com/everypolitician/everypolitician-popolo/pull/65 work everywhere.
