### PR TITLE
convert index result to array before intersecting in where

### DIFF
--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -32,7 +32,7 @@ module Everypolitician
       end
 
       def where(attributes = {})
-        attributes.map { |k, v| index_for(k.to_sym)[v] }.reduce(:&) || []
+          attributes.map { |k, v| index_for(k.to_sym)[v] }.reduce { |a, e| e.to_a & a } || []
       end
 
       private

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -32,12 +32,7 @@ module Everypolitician
       end
 
       def where(attributes = {})
-        results = attributes.map { |k, v| index_for(k.to_sym)[v] }
-        if results.all?
-          results.reduce(:&)
-        else
-          []
-        end
+        attributes.map { |k, v| index_for(k.to_sym)[v].to_a }.reduce(:&) || []
       end
 
       private

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -32,7 +32,12 @@ module Everypolitician
       end
 
       def where(attributes = {})
-          attributes.map { |k, v| index_for(k.to_sym)[v] }.reduce { |a, e| e.to_a & a } || []
+        results = attributes.map { |k, v| index_for(k.to_sym)[v] }
+        if results.all?
+          results.reduce(:&)
+        else
+          []
+        end
       end
 
       private

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -40,14 +40,9 @@ class CollectionTest < Minitest::Test
   end
 
   def test_where_finding_some_attributes_with_no_matches
-    popolo = Everypolitician::Popolo::JSON.new(
-      organizations: [
-        { id: 'representatives', name: "House o' Representin'", classification: 'legislature' },
-        { id: 'tomato', name: 'Sunripe Tomato Party', classification: 'party' },
-        { id: 'greens', name: 'The Greens', classification: 'party' },
-      ]
-    )
+    popolo = Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json')
 
     assert_equal popolo.organizations.where(classification: 'party', name: 'The Reds').count, 0
+    assert_equal popolo.organizations.where(name: 'The Reds', classification: 'party').count, 0
   end
 end

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -38,4 +38,16 @@ class CollectionTest < Minitest::Test
   def test_where_finding_on_memberships
     assert_equal popolo.memberships.where(person_id: '0259486a-0410-49f3-aef9-8b79c15741a7', legislative_period_id: 'term/13').count, 1
   end
+
+  def test_where_finding_some_attributes_with_no_matches
+    popolo = Everypolitician::Popolo::JSON.new(
+      organizations: [
+        { id: 'representatives', name: "House o' Representin'", classification: 'legislature' },
+        { id: 'tomato', name: 'Sunripe Tomato Party', classification: 'party' },
+        { id: 'greens', name: 'The Greens', classification: 'party' },
+      ]
+    )
+
+    assert_equal popolo.organizations.where(classification: 'party', name: 'The Reds').count, 0
+  end
 end


### PR DESCRIPTION
If the index has no matching results then it is nil and not [].
Intersect throws an exception if you try to run it on something that
isn't an array so convert it to an array first.

Note that this will throw an exception if we get something that doesn't
have a to_a method but that should not happen and if it does then
something has gone wrong.

Fixes #69
