### PR TITLE
check all attributes to determine membership equality

### DIFF
--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -8,7 +8,7 @@ module Everypolitician
       end
 
       def ==(other)
-        self.class == other.class && instance_variables.all? { |v| v == other[v] }
+        self.class == other.class && instance_variables.all? { |v| instance_variable_get(v) == other.instance_variable_get(v) }
       end
       alias eql? ==
     end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -6,6 +6,11 @@ module Everypolitician
       def person
         popolo.persons.find_by(id: person_id)
       end
+
+      def ==(other)
+        self.class == other.class && instance_variables.all? { |v| v == other[v] }
+      end
+      alias eql? ==
     end
 
     class Memberships < Collection

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -64,4 +64,10 @@ class CollectionTest < Minitest::Test
     assert_equal popolo.organizations.where(classification: 'party', name: 'The Greens').count, 1
     assert_equal popolo.organizations.where(classification: 'party', name: 'The Greens').first.id, 'greens'
   end
+
+  def test_where_finding_on_memberships
+    popolo = Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json')
+
+    assert_equal popolo.memberships.where(person_id: '0259486a-0410-49f3-aef9-8b79c15741a7', legislative_period_id: 'term/13').count, 1
+  end
 end

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -51,4 +51,9 @@ class MembershipTest < Minitest::Test
   def test_membership_person
     assert_equal 'Bob', popolo.memberships.first.person.name
   end
+
+  def test_membership_equality
+    memberships = Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json').memberships.to_a
+    assert_equal false, memberships[0] == memberships[1]
+  end
 end

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -54,6 +54,11 @@ class MembershipTest < Minitest::Test
 
   def test_membership_equality
     memberships = Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json').memberships.to_a
-    assert_equal false, memberships[0] == memberships[1]
+    assert_equal memberships[0], memberships[0]
+  end
+
+  def test_membership_inequality
+    memberships = Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json').memberships.to_a
+    refute_equal memberships[0], memberships[1]
   end
 end


### PR DESCRIPTION
Previously membership equality testing did not work as it was using .id
to compare which was always empty and so everything matched. Now we make
sure that all attributes are equal.

This also fixes searching on memberships using the new index method as
that uses the intersect method which compares objects using .eql?

Fixes #70
