### PR TITLE
Use real data in tests

### DIFF
--- a/test/everypolitician/popolo/area_test.rb
+++ b/test/everypolitician/popolo/area_test.rb
@@ -1,29 +1,40 @@
 require 'test_helper'
 
 class AreaTest < Minitest::Test
-  def test_reading_popolo_areas
-    popolo = Everypolitician::Popolo::JSON.new(
-      areas: [{ id: '123', name: 'Newtown', type: 'constituency' }]
-    )
-    area = popolo.areas.first
-
-    assert_instance_of Everypolitician::Popolo::Areas, popolo.areas
-    assert_instance_of Everypolitician::Popolo::Area, area
+  def fixture
+    'test/fixtures/estonia-ep-popolo-v1.0.json'
   end
 
-  def test_no_areas_in_popolo_data
-    popolo = Everypolitician::Popolo::JSON.new(other_data: [{ id: '123', foo: 'Bar' }])
-    assert_equal true, popolo.areas.none?
+  def areas
+    @areas ||= Everypolitician::Popolo.read(fixture).areas
   end
 
-  def test_accessing_area_properties
-    popolo = Everypolitician::Popolo::JSON.new(
-      areas: [{ id: '123', name: 'Newtown', type: 'constituency' }]
-    )
-    area = popolo.areas.first
+  def tartu
+    areas.find_by(name: 'Tartu linn')
+  end
 
-    assert_equal '123', area.id
-    assert_equal 'Newtown', area.name
-    assert_equal 'constituency', area.type
+  def test_areas_class
+    assert_instance_of Everypolitician::Popolo::Areas, areas
+  end
+
+  def test_area_class
+    assert_instance_of Everypolitician::Popolo::Area, areas.first
+  end
+
+  def test_id
+    assert_equal 'area/tartu_linn', tartu.id
+  end
+
+  def test_name
+    assert_equal 'Tartu linn', tartu.name
+  end
+
+  def test_type
+    assert_equal 'constituency', tartu.type
+  end
+
+  def test_wikidata
+    skip unless tartu.respond_to? 'wikidata'
+    assert_equal 'Q3032626', tartu.wikidata
   end
 end

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -1,73 +1,41 @@
 require 'test_helper'
 
 class CollectionTest < Minitest::Test
-  def test_find_by_finding_a_person
-    popolo = Everypolitician::Popolo::JSON.new(
-      persons: [{ id: 'abc', name: 'Jane' }, { id: '123', name: 'Bob' }]
-    )
+  def fixture
+    'test/fixtures/estonia-ep-popolo-v1.0.json'
+  end
 
-    assert_equal popolo.persons.find_by(id: '123').id, '123'
-    assert_equal popolo.persons.find_by(id: '123').name, 'Bob'
+  def popolo
+    @popolo ||= Everypolitician::Popolo.read(fixture)
+  end
+
+  def test_find_by_id
+    assert_equal 'Taavi Rõivas', popolo.persons.find_by(id: '6b71eefc-413d-4db6-88f0-d7ff845ebaf1').name
+  end
+
+  def test_find_by_name
+    assert_equal '6b71eefc-413d-4db6-88f0-d7ff845ebaf1', popolo.persons.find_by(name: 'Taavi Rõivas').id
   end
 
   def test_find_by_finding_no_item
-    popolo = Everypolitician::Popolo::JSON.new(
-      persons: [{ id: 'abc', name: 'Jane' }, { id: '123', name: 'Bob' }]
-    )
-
-    assert_equal popolo.persons.find_by(id: 'blah'), nil
+    assert_equal nil, popolo.persons.find_by(name: 'Raavi Tõivas')
   end
 
   def test_find_by_finding_an_organization_by_multiple_attributes
-    popolo = Everypolitician::Popolo::JSON.new(
-      organizations: [{ id: 'foo_corp', name: 'Foo Corp' }, { id: 'bar_corp', name: 'Bar Corp' }]
-    )
-
-    assert_equal popolo.organizations.find_by(id: 'foo_corp', name: 'Foo Corp').id, 'foo_corp'
-    assert_equal popolo.organizations.find_by(id: 'foo_corp', name: 'Foo Corp').name, 'Foo Corp'
+    assert_equal 'SDE', popolo.organizations.find_by(id: 'SDE', name: 'Sotsiaaldemokraatliku Erakonna fraktsioon').id
+    assert_equal nil, popolo.organizations.find_by(id: 'IRL', name: 'Sotsiaaldemokraatliku Erakonna fraktsioon')
   end
 
   def test_where_finding_multiple_parties
-    popolo = Everypolitician::Popolo::JSON.new(
-      organizations: [
-        { id: 'representatives', name: "House o' Representin'", classification: 'legislature' },
-        { id: 'tomato', name: 'Sunripe Tomato Party', classification: 'party' },
-        { id: 'greens', name: 'The Greens', classification: 'party' },
-      ]
-    )
-
-    assert_equal popolo.organizations.where(classification: 'party').count, 2
-    assert_equal popolo.organizations.where(classification: 'party').first.name, 'Sunripe Tomato Party'
+    assert_equal popolo.organizations.count, 8
+    assert_equal popolo.organizations.where(classification: 'party').count, 7
   end
 
   def test_where_finding_no_items
-    popolo = Everypolitician::Popolo::JSON.new(
-      organizations: [
-        { id: 'representatives', name: "House o' Representin'", classification: 'legislature' },
-        { id: 'tomato', name: 'Sunripe Tomato Party', classification: 'party' },
-        { id: 'greens', name: 'The Greens', classification: 'party' },
-      ]
-    )
-
     assert_equal popolo.organizations.where(classification: 'business'), []
   end
 
-  def test_where_finding_by_multiple_attributes
-    popolo = Everypolitician::Popolo::JSON.new(
-      organizations: [
-        { id: 'representatives', name: "House o' Representin'", classification: 'legislature' },
-        { id: 'tomato', name: 'Sunripe Tomato Party', classification: 'party' },
-        { id: 'greens', name: 'The Greens', classification: 'party' },
-      ]
-    )
-
-    assert_equal popolo.organizations.where(classification: 'party', name: 'The Greens').count, 1
-    assert_equal popolo.organizations.where(classification: 'party', name: 'The Greens').first.id, 'greens'
-  end
-
   def test_where_finding_on_memberships
-    popolo = Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json')
-
     assert_equal popolo.memberships.where(person_id: '0259486a-0410-49f3-aef9-8b79c15741a7', legislative_period_id: 'term/13').count, 1
   end
 end

--- a/test/everypolitician/popolo/organization_test.rb
+++ b/test/everypolitician/popolo/organization_test.rb
@@ -1,53 +1,40 @@
 require 'test_helper'
 
 class OrganizationTest < Minitest::Test
-  def test_reading_popolo_organizations
-    popolo = Everypolitician::Popolo::JSON.new(organizations: [{ id: '123', name: 'ACME' }])
-    assert_instance_of Everypolitician::Popolo::Organizations, popolo.organizations
-    organization = popolo.organizations.first
-    assert_instance_of Everypolitician::Popolo::Organization, organization
+  def fixture
+    'test/fixtures/estonia-ep-popolo-v1.0.json'
   end
 
-  def test_no_organizations_in_popolo_data
-    popolo = Everypolitician::Popolo::JSON.new(other_data: [{ id: '123', foo: 'Bar' }])
-    assert_equal true, popolo.organizations.none?
+  def orgs
+    @orgs ||= Everypolitician::Popolo.read(fixture).organizations
   end
 
-  def test_accessing_organization_properties
-    popolo = Everypolitician::Popolo::JSON.new(organizations: [{ id: '123', name: 'ACME' }])
-    organization = popolo.organizations.first
-    assert_equal '123', organization.id
-    assert_equal 'ACME', organization.name
+  def irl
+    orgs.find_by(id: 'IRL')
   end
 
-  def test_organization_equality_based_on_id
-    org1 = Everypolitician::Popolo::Organization.new(id: 'abc', name: 'ACME')
-    org2 = Everypolitician::Popolo::Organization.new(id: 'abc', name: 'ACME')
-    assert_equal org1, org2
+  def test_organizations_type
+    assert_instance_of Everypolitician::Popolo::Organizations, orgs
   end
 
-  def test_organizations_subtraction
-    org1 = { id: 'abc', name: 'ACME' }
-    org2 = { id: 'def', name: 'TNT INC' }
-    all_orgs = Everypolitician::Popolo::Organizations.new([org1, org2])
-    just_org_1 = Everypolitician::Popolo::Organizations.new([org1])
-    assert_equal [Everypolitician::Popolo::Organization.new(org2)], all_orgs - just_org_1
+  def test_organization_type
+    assert_instance_of Everypolitician::Popolo::Organization, orgs.first
   end
 
-  def test_organization_wikidata
-    org = Everypolitician::Popolo::Organization.new(
-      id:          'abc',
-      name:        'ACME',
-      identifiers: [{ identifier: 'Q288523', scheme: 'wikidata' }]
-    )
-    assert_equal 'Q288523', org.wikidata
+  def test_name
+    assert_equal 'Isamaa ja Res Publica Liidu fraktsioon', irl.name
   end
 
-  def test_organization_no_wikidata
-    org = Everypolitician::Popolo::Organization.new(
-      id:   'abc',
-      name: 'ACME'
-    )
-    assert_nil org.wikidata
+  def test_wikidata
+    assert_equal 'Q163347', irl.wikidata
+  end
+
+  def test_website
+    assert_equal 'http://www.irl.ee/', irl.links.first[:url]
+  end
+
+  def test_equality
+    assert_equal orgs.first, orgs.first
+    refute_equal orgs.first, orgs.drop(1).first
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'everypolitician/popolo'
+require 'pry'
 
 require 'minitest/autorun'


### PR DESCRIPTION
Testing against faked up data is fraught with peril. Instead let’s switch the Collection, Area, Person, Membership, and Organization tests to run against real data so we can be sure that things work against the format we actually encounter, not just the format expressed in the tests.
## Notes to reviewer

Not all tests have yet been migrated — some operate on a set-up that doesn't exist in the Estonian data (notably Posts, and dated names). 
