### PR TITLE
Add election and legislative period classes for events

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -47,16 +47,17 @@ module Everypolitician
         @memberships ||= Memberships.new(popolo[:memberships], self)
       end
 
+      def elections
+        @elections ||= events.elections
+      end
+
       def legislative_periods
-        @legislative_periods ||= LegislativePeriods.new(
-          popolo[:events].select { |e| e[:classification] == 'legislative period' },
-          self
-        ).sort_by(&:start_date)
+        @legislative_periods ||= events.legislative_periods
       end
       alias terms legislative_periods
 
       def current_legislative_period
-        legislative_periods.last
+        legislative_periods.first
       end
       alias current_term current_legislative_period
     end

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -48,7 +48,10 @@ module Everypolitician
       end
 
       def legislative_periods
-        events.where(classification: 'legislative period').sort_by(&:start_date)
+        @legislative_periods ||= LegislativePeriods.new(
+          popolo[:events].select { |e| e[:classification] == 'legislative period' },
+          self
+        ).sort_by(&:start_date)
       end
       alias terms legislative_periods
 

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -36,7 +36,8 @@ module Everypolitician
       end
 
       def events
-        @events ||= Events.new(popolo[:events], self)
+        # do the sorting at the popolo level so we still get an Events object back
+        @events ||= Events.new(popolo[:events].to_a.sort_by { |e| e['start_date'] }, self)
       end
 
       def posts

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -57,7 +57,7 @@ module Everypolitician
       alias terms legislative_periods
 
       def current_legislative_period
-        legislative_periods.first
+        legislative_periods.last
       end
       alias current_term current_legislative_period
     end

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -37,7 +37,7 @@ module Everypolitician
 
       def events
         # do the sorting at the popolo level so we still get an Events object back
-        @events ||= Events.new(popolo[:events].to_a.sort_by { |e| e['start_date'] }, self)
+        @events ||= Events.new(popolo[:events].to_a.sort_by { |e| e[:start_date] }, self)
       end
 
       def posts

--- a/lib/everypolitician/popolo/election.rb
+++ b/lib/everypolitician/popolo/election.rb
@@ -1,0 +1,9 @@
+module Everypolitician
+  module Popolo
+    class Election < Event
+    end
+    class Elections < Collection
+      entity_class Election
+    end
+  end
+end

--- a/lib/everypolitician/popolo/election.rb
+++ b/lib/everypolitician/popolo/election.rb
@@ -1,6 +1,7 @@
 module Everypolitician
   module Popolo
     class Election < Event
+      classification 'general election'
     end
     class Elections < Collection
       entity_class Election

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -4,6 +4,10 @@ module Everypolitician
       attr_reader :document
       attr_reader :popolo
 
+      def self.classification(classification = nil)
+        @classification ||= classification
+      end
+
       def initialize(document, popolo = nil)
         @document = document
         @popolo = popolo

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -65,7 +65,7 @@ module Everypolitician
       end
 
       def self.find_class(classification)
-        subclasses.select { |s| s.classification == classification }.first || default_class
+        subclasses.find { |s| s.classification == classification } || default_class
       end
     end
   end

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -50,5 +50,27 @@ module Everypolitician
         identifier('wikidata')
       end
     end
+
+    class DynamicEntity < Entity
+      def self.new(doc, *args)
+        find_class(doc[:classification]).new(doc, *args)
+      end
+
+      def self.classification(classification = nil)
+        @classification ||= classification
+      end
+
+      def self.subclasses(subclasses = [])
+        @subclasses ||= subclasses
+      end
+
+      def self.default_class(default_class = nil)
+        @default_class ||= default_class
+      end
+
+      def self.find_class(classification)
+        @subclasses[classification] ||= subclasses.select { |s| s.classification == classification }.first || default_class
+      end
+    end
   end
 end

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -51,13 +51,9 @@ module Everypolitician
       end
     end
 
-    class DynamicEntity < Entity
+    class EntityFactory
       def self.new(doc, *args)
         find_class(doc[:classification]).new(doc, *args)
-      end
-
-      def self.classification(classification = nil)
-        @classification ||= classification
       end
 
       def self.subclasses(subclasses = [])
@@ -69,7 +65,7 @@ module Everypolitician
       end
 
       def self.find_class(classification)
-        @subclasses[classification] ||= subclasses.select { |s| s.classification == classification }.first || default_class
+        subclasses.select { |s| s.classification == classification }.first || default_class
       end
     end
   end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -22,8 +22,29 @@ module Everypolitician
       end
     end
 
+    class DynamicEventClassFinder
+      def self.new(doc, *args)
+        case doc[:classification]
+        when 'general election'
+          Election.new(doc, *args)
+        when 'legislative period'
+          LegislativePeriod.new(doc, *args)
+        else
+          Event.new(doc, *args)
+        end
+      end
+    end
+
     class Events < Collection
-      entity_class Event
+      entity_class DynamicEventClassFinder
+
+      def elections
+        where(classification: 'general election')
+      end
+
+      def legislative_periods
+        where(classification: 'legislative period')
+      end
     end
   end
 end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -39,11 +39,11 @@ module Everypolitician
       entity_class DynamicEventClassFinder
 
       def elections
-        where(classification: 'general election')
+        where(classification: 'general election').sort_by(&:start_date)
       end
 
       def legislative_periods
-        where(classification: 'legislative period')
+        where(classification: 'legislative period').sort_by(&:start_date)
       end
     end
   end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -31,11 +31,11 @@ module Everypolitician
       entity_class EventFactory
 
       def elections
-        where(classification: 'general election')
+        where(classification: Election.classification)
       end
 
       def legislative_periods
-        where(classification: 'legislative period')
+        where(classification: LegislativePeriod.classification)
       end
     end
   end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,6 +1,9 @@
 module Everypolitician
   module Popolo
-    class Event < Entity
+    class Event < DynamicEntity
+      subclasses [Election, LegislativePeriod]
+      default_class Event
+
       def start_date
         document.fetch(:start_date, nil)
       end
@@ -22,24 +25,8 @@ module Everypolitician
       end
     end
 
-    class DynamicEventClassFinder
-      @subclasses = {}
-
-      def self.new(doc, *args)
-        find_class(doc[:classification]).new(doc, *args)
-      end
-
-      def self.subclasses
-        [Election, LegislativePeriod]
-      end
-
-      def self.find_class(classification)
-        @subclasses[classification] ||= subclasses.select { |s| s.classification == classification }.first || Event
-      end
-    end
-
     class Events < Collection
-      entity_class DynamicEventClassFinder
+      entity_class Event
 
       def elections
         where(classification: 'general election').sort_by(&:start_date)

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -31,11 +31,11 @@ module Everypolitician
       entity_class EventFactory
 
       def elections
-        where(classification: 'general election').sort_by(&:start_date)
+        where(classification: 'general election')
       end
 
       def legislative_periods
-        where(classification: 'legislative period').sort_by(&:start_date)
+        where(classification: 'legislative period')
       end
     end
   end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,9 +1,6 @@
 module Everypolitician
   module Popolo
-    class Event < DynamicEntity
-      subclasses [Election, LegislativePeriod]
-      default_class Event
-
+    class Event < Entity
       def start_date
         document.fetch(:start_date, nil)
       end
@@ -25,8 +22,13 @@ module Everypolitician
       end
     end
 
+    class EventFactory < EntityFactory
+      subclasses [Election, LegislativePeriod]
+      default_class Event
+    end
+
     class Events < Collection
-      entity_class Event
+      entity_class EventFactory
 
       def elections
         where(classification: 'general election').sort_by(&:start_date)

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -23,15 +23,18 @@ module Everypolitician
     end
 
     class DynamicEventClassFinder
+      @subclasses = {}
+
       def self.new(doc, *args)
-        case doc[:classification]
-        when 'general election'
-          Election.new(doc, *args)
-        when 'legislative period'
-          LegislativePeriod.new(doc, *args)
-        else
-          Event.new(doc, *args)
-        end
+        find_class(doc[:classification]).new(doc, *args)
+      end
+
+      def self.subclasses
+        [Election, LegislativePeriod]
+      end
+
+      def self.find_class(classification)
+        @subclasses[classification] ||= subclasses.select { |s| s.classification == classification }.first || Event
       end
     end
 

--- a/lib/everypolitician/popolo/legislative_period.rb
+++ b/lib/everypolitician/popolo/legislative_period.rb
@@ -1,0 +1,9 @@
+module Everypolitician
+  module Popolo
+    class LegislativePeriod < Event
+    end
+    class LegislativePeriods < Collection
+      entity_class LegislativePeriod
+    end
+  end
+end

--- a/lib/everypolitician/popolo/legislative_period.rb
+++ b/lib/everypolitician/popolo/legislative_period.rb
@@ -1,6 +1,7 @@
 module Everypolitician
   module Popolo
     class LegislativePeriod < Event
+      classification 'legislative period'
     end
     class LegislativePeriods < Collection
       entity_class LegislativePeriod

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -1,5 +1,9 @@
 require 'test_helper'
 class EventTest < Minitest::Test
+  def popolo
+    @popolo ||= Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json')
+  end
+
   def events
     @events ||= Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json').events
   end
@@ -7,6 +11,7 @@ class EventTest < Minitest::Test
   def test_reading_popolo_events
     event = events.first
     assert_instance_of Everypolitician::Popolo::Events, events
+    assert_kind_of Everypolitician::Popolo::Event, event
     assert_instance_of Everypolitician::Popolo::Election, event
   end
 
@@ -24,5 +29,26 @@ class EventTest < Minitest::Test
     assert_equal 'legislative period', event.classification
     assert_equal '1ba661a9-22ad-4d0f-8a60-fe8e28f2488c', event.organization_id
     assert_equal 'Q967549', event.wikidata
+  end
+
+  def test_accessing_legislative_periods
+    terms = popolo.legislative_periods
+    assert_equal 2, terms.count
+    term = terms.first
+    assert_instance_of Everypolitician::Popolo::LegislativePeriod, term
+    assert_equal 'term/12', term.id
+  end
+
+  def test_accessing_elections
+    elections = popolo.elections
+    assert_equal 14, elections.count
+    election = elections.first
+    assert_instance_of Everypolitician::Popolo::Election, election
+    assert_equal 'Q1891860', election.id
+  end
+
+  def test_falls_back_to_event_class
+    popolo = Everypolitician::Popolo::JSON.new(events: [{ classification: 'referendum', id: '123', foo: 'Bar' }])
+    assert_instance_of EveryPolitician::Popolo::Event, popolo.events.first
   end
 end

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -7,7 +7,7 @@ class EventTest < Minitest::Test
   def test_reading_popolo_events
     event = events.first
     assert_instance_of Everypolitician::Popolo::Events, events
-    assert_instance_of Everypolitician::Popolo::Event, event
+    assert_instance_of Everypolitician::Popolo::Election, event
   end
 
   def test_no_events_in_popolo_data

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -5,7 +5,7 @@ class EventTest < Minitest::Test
   end
 
   def events
-    @events ||= Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json').events
+    @events ||= popolo.events
   end
 
   def test_reading_popolo_events

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -27,7 +27,9 @@ class JsonTest < Minitest::Test
     assert_equal popolo_json.current_term, popolo_json.current_legislative_period
   end
 
-  def test_that_terms_returns_legislative_period_objects
+  def test_that_terms_returns_only_legislative_period_objects
+    assert_equal popolo_json.terms.count, 2
     assert_instance_of Everypolitician::Popolo::LegislativePeriod, popolo_json.terms.first
+    assert_instance_of Everypolitician::Popolo::LegislativePeriod, popolo_json.terms.last
   end
 end

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -26,4 +26,8 @@ class JsonTest < Minitest::Test
   def test_current_term_returns_the_same_as_current_legislative_period
     assert_equal popolo_json.current_term, popolo_json.current_legislative_period
   end
+
+  def test_that_terms_returns_legislative_period_objects
+    assert_instance_of Everypolitician::Popolo::LegislativePeriod, popolo_json.terms.first
+  end
 end

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -12,7 +12,7 @@ class JsonTest < Minitest::Test
   end
 
   def test_legislative_periods_ignores_other_event_types
-    assert_equal 2, popolo_json.legislative_periods.size
+    assert_equal 2, popolo_json.legislative_periods.count
   end
 
   def test_current_legislative_period_returns_correct_term
@@ -30,6 +30,6 @@ class JsonTest < Minitest::Test
   def test_that_terms_returns_only_legislative_period_objects
     assert_equal popolo_json.terms.count, 2
     assert_instance_of Everypolitician::Popolo::LegislativePeriod, popolo_json.terms.first
-    assert_instance_of Everypolitician::Popolo::LegislativePeriod, popolo_json.terms.last
+    assert_instance_of Everypolitician::Popolo::LegislativePeriod, popolo_json.terms.to_a.last
   end
 end


### PR DESCRIPTION
This adds terms/legislativeperiods and elections methods to popolo that return specific classes for those event types. It also updates Events to generate those classes as part of the Events collection.

Fixes #67
