### PR TITLE
Use `require_all` to pull in all the subclasses

### DIFF
--- a/everypolitician-popolo.gemspec
+++ b/everypolitician-popolo.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'require_all'
+
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -1,13 +1,7 @@
-require 'everypolitician/popolo/version'
-require 'everypolitician/popolo/collection'
-require 'everypolitician/popolo/entity'
-require 'everypolitician/popolo/person'
-require 'everypolitician/popolo/organization'
-require 'everypolitician/popolo/area'
-require 'everypolitician/popolo/event'
-require 'everypolitician/popolo/post'
-require 'everypolitician/popolo/membership'
 require 'json'
+require 'require_all'
+
+require_rel 'popolo'
 
 module Everypolitician
   module Popolo


### PR DESCRIPTION
Rather than explicitly requiring each of our files one by one, (and needing
to maintain this list as we add more), use `require_all` to pull them all
in in one shot.
