### PR TITLE
Create EntityWithDynamicMethods class

### DIFF
--- a/lib/everypolitician/popolo/area.rb
+++ b/lib/everypolitician/popolo/area.rb
@@ -1,6 +1,6 @@
 module Everypolitician
   module Popolo
-    class Area < Entity; end
+    class Area < EntityWithDynamicMethods; end
 
     class Areas < Collection
       entity_class Area

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -8,14 +8,6 @@ module Everypolitician
       def initialize(document, popolo = nil)
         @document = document
         @popolo = popolo
-
-        document.each do |key, value|
-          if respond_to?("#{key}=")
-            __send__("#{key}=", value)
-          else
-            define_singleton_method(key) { value }
-          end
-        end
       end
 
       def [](key)

--- a/lib/everypolitician/popolo/entity_with_dynamic_methods.rb
+++ b/lib/everypolitician/popolo/entity_with_dynamic_methods.rb
@@ -1,0 +1,18 @@
+module Everypolitician
+  module Popolo
+    class EntityWithDynamicMethods < Entity
+      def initialize(document, popolo = nil)
+        @document = document
+        @popolo = popolo
+
+        document.each do |key, value|
+          if respond_to?("#{key}=")
+            __send__("#{key}=", value)
+          else
+            define_singleton_method(key) { value }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,6 +1,6 @@
 module Everypolitician
   module Popolo
-    class Event < Entity
+    class Event < EntityWithDynamicMethods
       def initialize(document, _p)
         @document = document
       end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -1,6 +1,6 @@
 module Everypolitician
   module Popolo
-    class Membership < Entity
+    class Membership < EntityWithDynamicMethods
       attr_accessor :person_id, :on_behalf_of_id, :organization_id, :area_id, :role, :start_date, :end_date
 
       def person

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -1,6 +1,6 @@
 module Everypolitician
   module Popolo
-    class Organization < Entity
+    class Organization < EntityWithDynamicMethods
       def wikidata
         identifier('wikidata')
       end

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -1,6 +1,6 @@
 module Everypolitician
   module Popolo
-    class Person < Entity
+    class Person < EntityWithDynamicMethods
       class Error < StandardError; end
 
       attr_accessor :name, :email, :image, :gender, :birth_date, :death_date, :honorific_prefix, :honorific_suffix

--- a/lib/everypolitician/popolo/post.rb
+++ b/lib/everypolitician/popolo/post.rb
@@ -1,6 +1,6 @@
 module Everypolitician
   module Popolo
-    class Post < Entity
+    class Post < EntityWithDynamicMethods
       attr_reader :label
     end
 


### PR DESCRIPTION
As a step towards implementing real methods in Entity subclasses, we are
moving dynamic method generation over to the EntityWithDynamicMethods Entity
subclass. Dynamic method generation is removed from Entity.

All Entity subclasses now inherit from this as a stopgap -- classes will revert
back to inheriting from Entity once they implement their own real methods. When all
these subclasses use real methods, EntityWithDynamicMethods can be removed.

References: https://github.com/everypolitician/everypolitician-popolo/issues/54
