### PR TITLE
add real methods to membership

### DIFF
--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -33,6 +33,10 @@ module Everypolitician
         popolo.persons.find_by(id: person_id)
       end
 
+      def organization
+        popolo.organizations.find_by(id: organization_id)
+      end
+
       def ==(other)
         self.class == other.class && instance_variables.all? { |v| instance_variable_get(v) == other.instance_variable_get(v) }
       end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -1,7 +1,33 @@
 module Everypolitician
   module Popolo
     class Membership < Entity
-      attr_accessor :person_id, :on_behalf_of_id, :organization_id, :area_id, :role, :start_date, :end_date
+      def person_id
+        document.fetch(:person_id, nil)
+      end
+
+      def on_behalf_of_id
+        document.fetch(:on_behalf_of_id, nil)
+      end
+
+      def organization_id
+        document.fetch(:organization_id, nil)
+      end
+
+      def area_id
+        document.fetch(:area_id, nil)
+      end
+
+      def role
+        document.fetch(:role, nil)
+      end
+
+      def start_date
+        document.fetch(:start_date, nil)
+      end
+
+      def end_date
+        document.fetch(:end_date, nil)
+      end
 
       def person
         popolo.persons.find_by(id: person_id)

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -41,6 +41,10 @@ module Everypolitician
         popolo.organizations.find_by(id: on_behalf_of_id)
       end
 
+      def area
+        popolo.areas.find_by(id: area_id)
+      end
+
       def ==(other)
         self.class == other.class && instance_variables.all? { |v| instance_variable_get(v) == other.instance_variable_get(v) }
       end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -37,6 +37,10 @@ module Everypolitician
         popolo.organizations.find_by(id: organization_id)
       end
 
+      def on_behalf_of
+        popolo.organizations.find_by(id: on_behalf_of_id)
+      end
+
       def ==(other)
         self.class == other.class && instance_variables.all? { |v| instance_variable_get(v) == other.instance_variable_get(v) }
       end

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -61,6 +61,10 @@ class MembershipTest < Minitest::Test
     assert_equal '1ba661a9-22ad-4d0f-8a60-fe8e28f2488c', memberships.first.organization_id
   end
 
+  def test_membership_organization
+    assert_equal 'Riigikogu', memberships.first.organization.name
+  end
+
   def test_membership_inequality
     refute_equal memberships.first, memberships.drop(1).first
   end

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -45,6 +45,22 @@ class MembershipTest < Minitest::Test
     assert_equal memberships.first, memberships.first
   end
 
+  def test_membership_on_behalf_of
+    assert_equal 'IRL', memberships.first.on_behalf_of_id
+  end
+
+  def test_membership_area_id
+    assert_equal 'area/tartu_linn', memberships.first.area_id
+  end
+
+  def test_membership_role
+    assert_equal 'member', memberships.first.role
+  end
+
+  def test_membership_organization_id
+    assert_equal '1ba661a9-22ad-4d0f-8a60-fe8e28f2488c', memberships.first.organization_id
+  end
+
   def test_membership_inequality
     refute_equal memberships.first, memberships.drop(1).first
   end

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -69,6 +69,10 @@ class MembershipTest < Minitest::Test
     assert_equal 'Isamaa ja Res Publica Liidu fraktsioon', memberships.first.on_behalf_of.name
   end
 
+  def test_membership_area
+    assert_equal 'Tartu linn', memberships.first.area.name
+  end
+
   def test_membership_inequality
     refute_equal memberships.first, memberships.drop(1).first
   end

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -45,7 +45,7 @@ class MembershipTest < Minitest::Test
     assert_equal memberships.first, memberships.first
   end
 
-  def test_membership_on_behalf_of
+  def test_membership_on_behalf_of_id
     assert_equal 'IRL', memberships.first.on_behalf_of_id
   end
 
@@ -63,6 +63,10 @@ class MembershipTest < Minitest::Test
 
   def test_membership_organization
     assert_equal 'Riigikogu', memberships.first.organization.name
+  end
+
+  def test_membership_on_behalf_of
+    assert_equal 'Isamaa ja Res Publica Liidu fraktsioon', memberships.first.on_behalf_of.name
   end
 
   def test_membership_inequality


### PR DESCRIPTION
This replaces the autogenerated accessor methods for Membership with real methods.

Part of #54 
