### PR TITLE
Remove dynamic entity method generation

### DIFF
--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -7,14 +7,6 @@ module Everypolitician
       def initialize(document, popolo = nil)
         @document = document
         @popolo = popolo
-
-        document.each do |key, value|
-          if respond_to?("#{key}=")
-            __send__("#{key}=", value)
-          else
-            define_singleton_method(key) { value }
-          end
-        end
       end
 
       def id

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -1,7 +1,6 @@
 module Everypolitician
   module Popolo
     class Entity
-      attr_accessor :id
       attr_reader :document
       attr_reader :popolo
 
@@ -16,6 +15,10 @@ module Everypolitician
             define_singleton_method(key) { value }
           end
         end
+      end
+
+      def id
+        document.fetch(:id, nil)
       end
 
       def [](key)


### PR DESCRIPTION
This removes the code which dynamically generates method accessors now that they have been replaces with real methods.

It also adds the `id` method to `Entity`

Fixes #54
