### PR TITLE
Only define dynamic methods if a real one is missing

### DIFF
--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -1,7 +1,6 @@
 module Everypolitician
   module Popolo
     class Entity
-      attr_accessor :id
       attr_reader :document
       attr_reader :popolo
 
@@ -16,6 +15,10 @@ module Everypolitician
             define_singleton_method(key) { value }
           end
         end
+      end
+
+      def id
+        document.fetch(:id, nil)
       end
 
       def [](key)

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -13,10 +13,6 @@ module Everypolitician
         document[:end_date]
       end
 
-      def id
-        document[:id]
-      end
-
       def name
         document[:name]
       end


### PR DESCRIPTION
This updates the dynamic method generation code to loop over each key in the JSON and check for a method getter and if one is missing autogenerate a getter method. Previously we were checking for a setter method which now always fails as the real methods are getter only.

The code that uses any found setter has been removed.

This also adds an `.id` method to `Entity`.

Part of #54
