### PR TITLE
add missing methods to membership

### DIFF
--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -21,6 +21,10 @@ module Everypolitician
         document.fetch(:legislative_period_id, nil)
       end
 
+      def post_id
+        document.fetch(:post_id, nil)
+      end
+
       def role
         document.fetch(:role, nil)
       end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -59,6 +59,10 @@ module Everypolitician
         popolo.areas.find_by(id: area_id)
       end
 
+      def post
+        popolo.posts.find_by(id: post_id)
+      end
+
       def ==(other)
         self.class == other.class && instance_variables.all? { |v| instance_variable_get(v) == other.instance_variable_get(v) }
       end

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -85,6 +85,12 @@ class MembershipTest < Minitest::Test
     assert_equal "women's_representative", nyeri.post_id
   end
 
+  def test_membership_post
+    assert_equal nil, memberships.first.post
+    assert_instance_of Everypolitician::Popolo::Post, nyeri.post
+    assert_equal "Women's Representative", nyeri.post.label
+  end
+
   def test_membership_legislative_period
     assert_equal '13th Riigikogu', memberships.first.legislative_period.name
     assert_equal '13th Riigikogu', memberships.first.term.name

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -5,8 +5,19 @@ class MembershipTest < Minitest::Test
     'test/fixtures/estonia-ep-popolo-v1.0.json'
   end
 
+  def kenya_fixture
+    'test/fixtures/kenya-ep-popolo-v1.0.json'
+  end
+
   def memberships
     @mems ||= Everypolitician::Popolo.read(fixture).memberships
+  end
+
+  def nyeri
+    Everypolitician::Popolo.read(kenya_fixture).memberships.where(
+      person_id:             '037a05a5-bee2-44f1-bfaa-d864ac35196f',
+      legislative_period_id: 'term/11'
+    ).first
   end
 
   def test_memberships_class
@@ -67,6 +78,11 @@ class MembershipTest < Minitest::Test
 
   def test_membership_legislative_period_id
     assert_equal 'term/13', memberships.first.legislative_period_id
+  end
+
+  def test_membership_post_id
+    assert_equal nil, memberships.first.post_id
+    assert_equal "women's_representative", nyeri.post_id
   end
 
   def test_membership_legislative_period


### PR DESCRIPTION
Adds post_id and post method to organization.

Part of #54 
