### PR TITLE
Add id method to Entity

### DIFF
--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -1,7 +1,6 @@
 module Everypolitician
   module Popolo
     class Entity
-      attr_accessor :id
       attr_reader :document
       attr_reader :popolo
 
@@ -16,6 +15,10 @@ module Everypolitician
             define_singleton_method(key) { value }
           end
         end
+      end
+
+      def id
+        document.fetch(:id, nil)
       end
 
       def [](key)

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -13,10 +13,6 @@ module Everypolitician
         document[:end_date]
       end
 
-      def id
-        document[:id]
-      end
-
       def name
         document[:name]
       end


### PR DESCRIPTION
Adds a real `id` method to `Entity` so that is available everywhere.

Removes the now un-needed `id` method from `Event`.

Part of #54.
