### PR TITLE
Return a Collection from where method

### DIFF
--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -32,7 +32,7 @@ module Everypolitician
       end
 
       def where(attributes = {})
-        self.class.new(attributes.map { |k, v| index_for(k.to_sym)[v].to_a }.reduce(:&).map(&:document) || [], popolo)
+        new_collection(attributes.map { |k, v| index_for(k.to_sym)[v].to_a }.reduce(:&))
       end
 
       def empty?
@@ -43,6 +43,10 @@ module Everypolitician
 
       def index_for(attr)
         @indexes[attr] ||= group_by(&attr)
+      end
+
+      def new_collection(entities)
+        self.class.new(entities.to_a.map(&:document), popolo)
       end
     end
   end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -35,6 +35,10 @@ module Everypolitician
         self.class.new(attributes.map { |k, v| index_for(k.to_sym)[v].to_a }.reduce(:&).map(&:document) || [], popolo)
       end
 
+      def empty?
+        count.zero?
+      end
+
       private
 
       def index_for(attr)

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -32,7 +32,7 @@ module Everypolitician
       end
 
       def where(attributes = {})
-        attributes.map { |k, v| index_for(k.to_sym)[v].to_a }.reduce(:&) || []
+        self.class.new(attributes.map { |k, v| index_for(k.to_sym)[v].to_a }.reduce(:&).map(&:document) || [], popolo)
       end
 
       private

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -29,13 +29,16 @@ class CollectionTest < Minitest::Test
   def test_where_finding_multiple_parties
     assert_equal popolo.organizations.count, 8
     assert_equal popolo.organizations.where(classification: 'party').count, 7
+    assert_instance_of Everypolitician::Popolo::Organizations, popolo.organizations.where(classification: 'party')
   end
 
   def test_where_finding_no_items
-    assert_equal popolo.organizations.where(classification: 'business'), []
+    assert_equal popolo.organizations.where(classification: 'business').count, 0
   end
 
   def test_where_finding_on_memberships
+    mem = popolo.memberships.where(person_id: '0259486a-0410-49f3-aef9-8b79c15741a7', legislative_period_id: 'term/13')
+    assert_instance_of Everypolitician::Popolo::Memberships, mem
     assert_equal popolo.memberships.where(person_id: '0259486a-0410-49f3-aef9-8b79c15741a7', legislative_period_id: 'term/13').count, 1
   end
 

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -45,6 +45,7 @@ class CollectionTest < Minitest::Test
   def test_where_finding_some_attributes_with_no_matches
     popolo = Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json')
 
+    assert_equal popolo.organizations.where(classification: 'party', name: 'The Reds').empty?, true
     assert_equal popolo.organizations.where(classification: 'party', name: 'The Reds').count, 0
     assert_equal popolo.organizations.where(name: 'The Reds', classification: 'party').count, 0
   end

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -182,7 +182,7 @@ class PersonTest
   end
 
   def test_memberships
-    assert_equal 2, etti.memberships.size
+    assert_equal 2, etti.memberships.count
     assert_equal '2014-03-27', etti.memberships.first.start_date
   end
 


### PR DESCRIPTION
This changes `Collection.where` to return another Collection based
object rather than an array. This is to allow further calls to `.where`
and `.find_by` to be done on the results. This is less important for
primary calls but more useful when the result is returned from methods
like `.terms`.

Fixes #97
