### PR TITLE
remove the overridden initialize method from Event

### DIFF
--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,10 +1,6 @@
 module Everypolitician
   module Popolo
     class Event < Entity
-      def initialize(document, _p)
-        @document = document
-      end
-
       def start_date
         document[:start_date]
       end
@@ -24,10 +20,6 @@ module Everypolitician
       def organization_id
         document[:organization_id]
       end
-
-      private
-
-      attr_reader :document
     end
 
     class Events < Collection


### PR DESCRIPTION
Event had its own `initialize` method which was not setting `@popolo`, this meant that code  using `.popolo` on Events would break with an `undefined method 'memberships' for nil:NilClass` type error.

This removes the overridden `initialize` and restores the default behaviour.

Fixes the build error in
https://github.com/everypolitician/everypolitician-data/pull/18542 which was caused by `Everypolitician::DataView::Terms.term_memberships` trying to access `popolo.memberships`.
