### PR TITLE
harmonize Event accessors with other Enity based classes

### DIFF
--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -2,23 +2,23 @@ module Everypolitician
   module Popolo
     class Event < Entity
       def start_date
-        document[:start_date]
+        document.fetch(:start_date, nil)
       end
 
       def end_date
-        document[:end_date]
+        document.fetch(:end_date, nil)
       end
 
       def name
-        document[:name]
+        document.fetch(:name, nil)
       end
 
       def classification
-        document[:classification]
+        document.fetch(:classification, nil)
       end
 
       def organization_id
-        document[:organization_id]
+        document.fetch(:organization_id, nil)
       end
     end
 


### PR DESCRIPTION
use document.fetch instead of document[] in line with other Entity based classes methods.
