### PR TITLE
Add Election and LegislativePeriod Events subclasses

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -47,8 +47,12 @@ module Everypolitician
         @memberships ||= Memberships.new(popolo[:memberships], self)
       end
 
+      def elections
+        @elections ||= events.elections
+      end
+
       def legislative_periods
-        events.where(classification: 'legislative period').sort_by(&:start_date)
+        @legislative_periods ||= events.legislative_periods
       end
       alias terms legislative_periods
 

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -36,7 +36,8 @@ module Everypolitician
       end
 
       def events
-        @events ||= Events.new(popolo[:events], self)
+        # do the sorting at the popolo level so we still get an Events object back
+        @events ||= Events.new(popolo[:events].to_a.sort_by { |e| e[:start_date] }, self)
       end
 
       def posts

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -55,10 +55,8 @@ module Everypolitician
         self.class.new(entities.to_a.map(&:document), popolo)
       end
 
-      def class_for_entity(document)
-        @event_class[document[:classification]] ||= self.class.entity_class.subclasses.find do |e|
-          e.classification == document[:classification]
-        end || self.class.entity_class
+      def class_for_entity(_document)
+        self.class.entity_class
       end
     end
   end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -13,7 +13,7 @@ module Everypolitician
       end
 
       def initialize(documents, popolo = nil)
-        @event_class = {}
+        @entity_class = {}
         @documents = documents ? documents.map { |p| class_for_entity(p).new(p, popolo) } : []
         @popolo = popolo
         @indexes = {}

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -14,7 +14,7 @@ module Everypolitician
 
       def initialize(documents, popolo = nil)
         @event_class = {}
-        @documents = documents ? documents.map { |p| class_for_entity(p[:classification]).new(p, popolo) } : []
+        @documents = documents ? documents.map { |p| class_for_entity(p).new(p, popolo) } : []
         @popolo = popolo
         @indexes = {}
         @of_class = {}
@@ -55,9 +55,9 @@ module Everypolitician
         self.class.new(entities.to_a.map(&:document), popolo)
       end
 
-      def class_for_entity(classification)
-        @event_class[classification] ||= self.class.entity_class.subclasses.select do |e|
-          e.classification == classification
+      def class_for_entity(document)
+        @event_class[document[:classification]] ||= self.class.entity_class.subclasses.select do |e|
+          e.classification == document[:classification]
         end.first || self.class.entity_class
       end
     end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -13,7 +13,8 @@ module Everypolitician
       end
 
       def initialize(documents, popolo = nil)
-        @documents = documents ? documents.map { |p| self.class.entity_class.new(p, popolo) } : []
+        @event_class = {}
+        @documents = documents ? documents.map { |p| class_for_entity(p[:classification]).new(p, popolo) } : []
         @popolo = popolo
         @indexes = {}
       end
@@ -47,6 +48,12 @@ module Everypolitician
 
       def new_collection(entities)
         self.class.new(entities.to_a.map(&:document), popolo)
+      end
+
+      def class_for_entity(classification)
+        @event_class[classification] ||= self.class.entity_class.subclasses.select do |e|
+          e.classification == classification
+        end.first || self.class.entity_class
       end
     end
   end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -56,9 +56,9 @@ module Everypolitician
       end
 
       def class_for_entity(document)
-        @event_class[document[:classification]] ||= self.class.entity_class.subclasses.select do |e|
+        @event_class[document[:classification]] ||= self.class.entity_class.subclasses.find do |e|
           e.classification == document[:classification]
-        end.first || self.class.entity_class
+        end || self.class.entity_class
       end
     end
   end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -17,6 +17,7 @@ module Everypolitician
         @documents = documents ? documents.map { |p| class_for_entity(p[:classification]).new(p, popolo) } : []
         @popolo = popolo
         @indexes = {}
+        @of_class = {}
       end
 
       def each(&block)
@@ -38,6 +39,10 @@ module Everypolitician
 
       def empty?
         count.zero?
+      end
+
+      def of_class(klass)
+        @of_class[klass] ||= select { |e| e.class == klass }
       end
 
       private

--- a/lib/everypolitician/popolo/election.rb
+++ b/lib/everypolitician/popolo/election.rb
@@ -1,0 +1,9 @@
+module Everypolitician
+  module Popolo
+    class Election < Event
+    end
+    class Elections < Collection
+      entity_class Election
+    end
+  end
+end

--- a/lib/everypolitician/popolo/election.rb
+++ b/lib/everypolitician/popolo/election.rb
@@ -1,6 +1,7 @@
 module Everypolitician
   module Popolo
     class Election < Event
+      classification 'general election'
     end
     class Elections < Collection
       entity_class Election

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -8,6 +8,15 @@ module Everypolitician
         @classification ||= classification
       end
 
+      def self.inherited(subclass)
+        @subclasses ||= []
+        @subclasses.push(subclass)
+      end
+
+      def self.subclasses
+        @subclasses || []
+      end
+
       def initialize(document, popolo = nil)
         @document = document
         @popolo = popolo

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -4,6 +4,10 @@ module Everypolitician
       attr_reader :document
       attr_reader :popolo
 
+      def self.classification(classification = nil)
+        @classification ||= classification
+      end
+
       def initialize(document, popolo = nil)
         @document = document
         @popolo = popolo
@@ -44,6 +48,24 @@ module Everypolitician
 
       def wikidata
         identifier('wikidata')
+      end
+    end
+
+    class EntityFactory
+      def self.new(doc, *args)
+        find_class(doc[:classification]).new(doc, *args)
+      end
+
+      def self.subclasses(subclasses = [])
+        @subclasses ||= subclasses
+      end
+
+      def self.default_class(default_class = nil)
+        @default_class ||= default_class
+      end
+
+      def self.find_class(classification)
+        subclasses.find { |s| s.classification == classification } || default_class
       end
     end
   end

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -50,23 +50,5 @@ module Everypolitician
         identifier('wikidata')
       end
     end
-
-    class EntityFactory
-      def self.new(doc, *args)
-        find_class(doc[:classification]).new(doc, *args)
-      end
-
-      def self.subclasses(subclasses = [])
-        @subclasses ||= subclasses
-      end
-
-      def self.default_class(default_class = nil)
-        @default_class ||= default_class
-      end
-
-      def self.find_class(classification)
-        subclasses.find { |s| s.classification == classification } || default_class
-      end
-    end
   end
 end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -34,7 +34,7 @@ module Everypolitician
       end
 
       def class_for_entity(document)
-        @event_class[document[:classification]] ||= self.class.entity_class.subclasses.find do |e|
+        @entity_class[document[:classification]] ||= self.class.entity_class.subclasses.find do |e|
           e.classification == document[:classification]
         end || self.class.entity_class
       end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -32,6 +32,12 @@ module Everypolitician
       def legislative_periods
         of_class(LegislativePeriod)
       end
+
+      def class_for_entity(document)
+        @event_class[document[:classification]] ||= self.class.entity_class.subclasses.find do |e|
+          e.classification == document[:classification]
+        end || self.class.entity_class
+      end
     end
   end
 end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -26,11 +26,11 @@ module Everypolitician
       entity_class Event
 
       def elections
-        where(classification: Election.classification)
+        of_class(Election)
       end
 
       def legislative_periods
-        where(classification: LegislativePeriod.classification)
+        of_class(LegislativePeriod)
       end
     end
   end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -22,8 +22,21 @@ module Everypolitician
       end
     end
 
+    class EventFactory < EntityFactory
+      subclasses [Election, LegislativePeriod]
+      default_class Event
+    end
+
     class Events < Collection
-      entity_class Event
+      entity_class EventFactory
+
+      def elections
+        where(classification: Election.classification)
+      end
+
+      def legislative_periods
+        where(classification: LegislativePeriod.classification)
+      end
     end
   end
 end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -22,13 +22,8 @@ module Everypolitician
       end
     end
 
-    class EventFactory < EntityFactory
-      subclasses [Election, LegislativePeriod]
-      default_class Event
-    end
-
     class Events < Collection
-      entity_class EventFactory
+      entity_class Event
 
       def elections
         where(classification: Election.classification)

--- a/lib/everypolitician/popolo/legislative_period.rb
+++ b/lib/everypolitician/popolo/legislative_period.rb
@@ -1,0 +1,9 @@
+module Everypolitician
+  module Popolo
+    class LegislativePeriod < Event
+    end
+    class LegislativePeriods < Collection
+      entity_class LegislativePeriod
+    end
+  end
+end

--- a/lib/everypolitician/popolo/legislative_period.rb
+++ b/lib/everypolitician/popolo/legislative_period.rb
@@ -1,6 +1,7 @@
 module Everypolitician
   module Popolo
     class LegislativePeriod < Event
+      classification 'legislative period'
     end
     class LegislativePeriods < Collection
       entity_class LegislativePeriod

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -1,12 +1,17 @@
 require 'test_helper'
 class EventTest < Minitest::Test
+  def popolo
+    @popolo ||= Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json')
+  end
+
   def events
-    @events ||= Everypolitician::Popolo.read('test/fixtures/estonia-ep-popolo-v1.0.json').events
+    @events ||= popolo.events
   end
 
   def test_reading_popolo_events
     event = events.first
     assert_instance_of Everypolitician::Popolo::Events, events
+    assert_kind_of Everypolitician::Popolo::Event, event
     assert_instance_of Everypolitician::Popolo::Election, event
   end
 
@@ -24,5 +29,26 @@ class EventTest < Minitest::Test
     assert_equal 'legislative period', event.classification
     assert_equal '1ba661a9-22ad-4d0f-8a60-fe8e28f2488c', event.organization_id
     assert_equal 'Q967549', event.wikidata
+  end
+
+  def test_accessing_legislative_periods
+    terms = popolo.legislative_periods
+    assert_equal 2, terms.count
+    term = terms.first
+    assert_instance_of Everypolitician::Popolo::LegislativePeriod, term
+    assert_equal 'term/12', term.id
+  end
+
+  def test_accessing_elections
+    elections = popolo.elections
+    assert_equal 14, elections.count
+    election = elections.first
+    assert_instance_of Everypolitician::Popolo::Election, election
+    assert_equal 'Q1891860', election.id
+  end
+
+  def test_falls_back_to_event_class
+    popolo = Everypolitician::Popolo::JSON.new(events: [{ classification: 'referendum', id: '123', foo: 'Bar' }])
+    assert_instance_of EveryPolitician::Popolo::Event, popolo.events.first
   end
 end

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -7,7 +7,7 @@ class EventTest < Minitest::Test
   def test_reading_popolo_events
     event = events.first
     assert_instance_of Everypolitician::Popolo::Events, events
-    assert_instance_of Everypolitician::Popolo::Event, event
+    assert_instance_of Everypolitician::Popolo::Election, event
   end
 
   def test_no_events_in_popolo_data

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -12,7 +12,7 @@ class JsonTest < Minitest::Test
   end
 
   def test_legislative_periods_ignores_other_event_types
-    assert_equal 2, popolo_json.legislative_periods.size
+    assert_equal 2, popolo_json.legislative_periods.count
   end
 
   def test_current_legislative_period_returns_correct_term
@@ -25,5 +25,11 @@ class JsonTest < Minitest::Test
 
   def test_current_term_returns_the_same_as_current_legislative_period
     assert_equal popolo_json.current_term, popolo_json.current_legislative_period
+  end
+
+  def test_that_terms_returns_only_legislative_period_objects
+    assert_equal popolo_json.terms.count, 2
+    assert_instance_of Everypolitician::Popolo::LegislativePeriod, popolo_json.terms.first
+    assert_instance_of Everypolitician::Popolo::LegislativePeriod, popolo_json.terms.to_a.last
   end
 end


### PR DESCRIPTION
This adds Election and LegislativePeriod subclasses to Event. The Event class will now return one of these if the popolo document passed in is an election or legislative period, otherwise it will return a plain Event class.

This also adds `elections` and `terms` methods to the Events class and uses them in the `Popolo` class methods of the same name.

Fixes #67
