### PR TITLE
Add LegislativeMembership subclass to membership

### DIFF
--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -14,8 +14,8 @@ module Everypolitician
 
       def initialize(documents, popolo = nil)
         @entity_class = {}
-        @documents = documents ? documents.map { |p| class_for_entity(p, popolo).new(p, popolo) } : []
         @popolo = popolo
+        @documents = documents ? documents.map { |p| class_for_entity(p).new(p, popolo) } : []
         @indexes = {}
         @of_class = {}
       end
@@ -55,7 +55,7 @@ module Everypolitician
         self.class.new(entities.to_a.map(&:document), popolo)
       end
 
-      def class_for_entity(_document, _popolo)
+      def class_for_entity(_document)
         self.class.entity_class
       end
     end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -14,7 +14,7 @@ module Everypolitician
 
       def initialize(documents, popolo = nil)
         @entity_class = {}
-        @documents = documents ? documents.map { |p| class_for_entity(p).new(p, popolo) } : []
+        @documents = documents ? documents.map { |p| class_for_entity(p, popolo).new(p, popolo) } : []
         @popolo = popolo
         @indexes = {}
         @of_class = {}
@@ -55,7 +55,7 @@ module Everypolitician
         self.class.new(entities.to_a.map(&:document), popolo)
       end
 
-      def class_for_entity(_document)
+      def class_for_entity(_document, _popolo)
         self.class.entity_class
       end
     end

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -33,7 +33,7 @@ module Everypolitician
         of_class(LegislativePeriod)
       end
 
-      def class_for_entity(document, _popolo)
+      def class_for_entity(document)
         @entity_class[document[:classification]] ||= self.class.entity_class.subclasses.find do |e|
           e.classification == document[:classification]
         end || self.class.entity_class

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -33,7 +33,7 @@ module Everypolitician
         of_class(LegislativePeriod)
       end
 
-      def class_for_entity(document)
+      def class_for_entity(document, _popolo)
         @entity_class[document[:classification]] ||= self.class.entity_class.subclasses.find do |e|
           e.classification == document[:classification]
         end || self.class.entity_class

--- a/lib/everypolitician/popolo/legislative_membership.rb
+++ b/lib/everypolitician/popolo/legislative_membership.rb
@@ -1,0 +1,10 @@
+module Everypolitician
+  module Popolo
+    class LegislativeMembership < Membership
+      classification 'legislature'
+    end
+    class LegislativeMemberships < Memberships
+      entity_class LegislativeMembership
+    end
+  end
+end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -73,6 +73,12 @@ module Everypolitician
 
     class Memberships < Collection
       entity_class Membership
+
+      def class_for_entity(document, popolo)
+        @entity_class[document[:organization_id]] ||= self.class.entity_class.subclasses.find do |e|
+          e.classification == popolo.organizations.find_by(id: document[:organization_id])[:classification]
+        end || self.class.entity_class
+      end
     end
   end
 end

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -74,7 +74,7 @@ module Everypolitician
     class Memberships < Collection
       entity_class Membership
 
-      def class_for_entity(document, popolo)
+      def class_for_entity(document)
         @entity_class[document[:organization_id]] ||= self.class.entity_class.subclasses.find do |e|
           e.classification == popolo.organizations.find_by(id: document[:organization_id])[:classification]
         end || self.class.entity_class

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -56,7 +56,7 @@ class EventTest < Minitest::Test
     term = popolo.terms.first
     memberships = term.memberships
     assert_equal memberships.count, 165
-    assert_instance_of EveryPolitician::Popolo::Membership, memberships.first
+    assert_instance_of EveryPolitician::Popolo::LegislativeMembership, memberships.first
     assert_equal memberships.first.person_id, '0259486a-0410-49f3-aef9-8b79c15741a7'
     org_ids = memberships.map(&:organization_id).to_set
     assert_equal org_ids.count, 1

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -25,7 +25,8 @@ class MembershipTest < Minitest::Test
   end
 
   def test_membership_class
-    assert_instance_of Everypolitician::Popolo::Membership, memberships.first
+    assert_kind_of Everypolitician::Popolo::Membership, memberships.first
+    assert_instance_of Everypolitician::Popolo::LegislativeMembership, memberships.first
   end
 
   def test_membership_with_start_date


### PR DESCRIPTION
This overrides the `class_for_entity` method in memberships to use the classification of the membership's organization to determine which memberships are for a Legislature.

Fixes #112
