### PR TITLE
add memberships method to terms

### DIFF
--- a/lib/everypolitician/popolo/legislative_period.rb
+++ b/lib/everypolitician/popolo/legislative_period.rb
@@ -2,6 +2,10 @@ module Everypolitician
   module Popolo
     class LegislativePeriod < Event
       classification 'legislative period'
+
+      def memberships
+        @memberships ||= popolo.memberships.where(legislative_period_id: id)
+      end
     end
     class LegislativePeriods < Collection
       entity_class LegislativePeriod

--- a/lib/everypolitician/popolo/legislative_period.rb
+++ b/lib/everypolitician/popolo/legislative_period.rb
@@ -4,7 +4,7 @@ module Everypolitician
       classification 'legislative period'
 
       def memberships
-        @memberships ||= popolo.memberships.where(legislative_period_id: id)
+        @memberships ||= popolo.memberships.where(legislative_period_id: id, organization_id: organization_id)
       end
     end
     class LegislativePeriods < Collection

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -58,5 +58,8 @@ class EventTest < Minitest::Test
     assert_equal memberships.count, 165
     assert_instance_of EveryPolitician::Popolo::Membership, memberships.first
     assert_equal memberships.first.person_id, '0259486a-0410-49f3-aef9-8b79c15741a7'
+    org_ids = memberships.map(&:organization_id).to_set
+    assert_equal org_ids.count, 1
+    assert_equal org_ids.first, '1ba661a9-22ad-4d0f-8a60-fe8e28f2488c'
   end
 end

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -51,4 +51,12 @@ class EventTest < Minitest::Test
     popolo = Everypolitician::Popolo::JSON.new(events: [{ classification: 'referendum', id: '123', foo: 'Bar' }])
     assert_instance_of EveryPolitician::Popolo::Event, popolo.events.first
   end
+
+  def test_term_memberships
+    term = popolo.terms.first
+    memberships = term.memberships
+    assert_equal memberships.count, 165
+    assert_instance_of EveryPolitician::Popolo::Membership, memberships.first
+    assert_equal memberships.first.person_id, '0259486a-0410-49f3-aef9-8b79c15741a7'
+  end
 end


### PR DESCRIPTION
This adds a `memberships` method to `LegislativePeriod` objects which returns all the `Membership`s for that legislative period.

Fixes #77 
