### PR TITLE
rename current_term to latest term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Moving away from generating accessors to Popolo properties dynamically
-  which means that in future only properties that are used by
-  EveryPolitician will have accessors
+- Accessors are no longer generated dynamically for Popolo properties,
+  which means that all normal accessor methods will now exist even where
+  a record doesn’t have that property.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.8.0] - 2016-09-26
+## [0.8.0] - 2016-10-26
 
 ### Added
 
@@ -97,3 +97,4 @@ exist, rather than blowing up.
 [0.5.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.4.0...v0.5.0
 [0.6.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.5.0...v0.6.0
 [0.7.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.6.0...v0.7.0
+[0.8.0]: https://github.com/everypolitician/everypolitician-popolo/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   functionality. It will return the most recent term for the legislature
   but it is not guaranteed that the term will be a current one. You
   should check the `start_date` and `end_date` of the term to determine that.
+- Added `Election` and `LegislativePeriod` classes for `Event`s.
+- `Collection.where` now returns a `Collection` rather and an `Array`
+- Added the following shortcut methods:
+  - `Membership.area`
+  - `Membership.legislative_period` or `Memberships.term`
+  - `Membership.person`
+  - `Membership.on_behalf_of` or `Membership.party`
+  - `Membership.organization`
+  - `Membership.post`
+  - `Post.organization`
+  - `Person.memberships`
+
+### Changed
+
+- Moving away from generating accessors to Popolo properties dynamically
+  which means that in future only properties that are used by
+  EveryPolitician will have accessors
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.8.0] - 2016-10-26
+## [0.8.0] - 2016-10-28
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Popolo.latest_term` replaces `Popolo.current_term` and has the same
   functionality. It will return the most recent term for the legislature
-  but it is not guaranteed that the term will be a concurent one. You
+  but it is not guaranteed that the term will be a current one. You
   should check the `start_date` and `end_date` of the term to determine that.
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.8.0] - 2016-09-26
+
+### Added
+
+- `Popolo.latest_term` replaces `Popolo.current_term` and has the same
+  functionality. It will return the most recent term for the legislature
+  but it is not guaranteed that the term will be a concurent one. You
+  should check the `start_date` and `end_date` of the term to determine that.
+
+### Deprecated
+
+- `Popolo.current_term` - use `latest_term` instead.
+
 ## [0.7.0] - 2016-09-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- `Popolo.latest_term` replaces `Popolo.current_term` and has the same
+- `Popolo#latest_term` replaces `Popolo#current_term` and has the same
   functionality. It will return the most recent term for the legislature
   but it is not guaranteed that the term will be a current one. You
   should check the `start_date` and `end_date` of the term to determine that.
 - Added `Election` and `LegislativePeriod` classes for `Event`s.
-- `Collection.where` now returns a `Collection` rather and an `Array`
+- `Collection#where` now returns a `Collection` rather and an `Array`
 - Added the following shortcut methods:
-  - `Membership.area`
-  - `Membership.legislative_period` or `Memberships.term`
-  - `Membership.person`
-  - `Membership.on_behalf_of` or `Membership.party`
-  - `Membership.organization`
-  - `Membership.post`
-  - `Post.organization`
-  - `Person.memberships`
+  - `Membership#area`
+  - `Membership#legislative_period` or `Memberships#term`
+  - `Membership#person`
+  - `Membership#on_behalf_of` or `Membership#party`
+  - `Membership#organization`
+  - `Membership#post`
+  - `Post#organization`
+  - `Person#memberships`
 
 ### Changed
 
@@ -31,7 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
-- `Popolo.current_term` - use `latest_term` instead.
+- `Popolo#current_term` - use `latest_term` instead.
 
 ## [0.7.0] - 2016-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   but it is not guaranteed that the term will be a current one. You
   should check the `start_date` and `end_date` of the term to determine that.
 - Added `Election` and `LegislativePeriod` classes for `Event`s.
-- `Collection#where` now returns a `Collection` rather and an `Array`
+- `Collection#where` now returns a `Collection` rather than an `Array`
 - Added the following shortcut methods:
   - `Membership#area`
-  - `Membership#legislative_period` or `Memberships#term`
+  - `Membership#legislative_period` or `Membership#term`
   - `Membership#person`
   - `Membership#on_behalf_of` or `Membership#party`
   - `Membership#organization`

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -57,10 +57,13 @@ module Everypolitician
       end
       alias terms legislative_periods
 
-      def current_legislative_period
+      def latest_legislative_period
         legislative_periods.max_by(&:start_date)
       end
-      alias current_term current_legislative_period
+      alias latest_term latest_legislative_period
+
+      alias current_legislative_period latest_legislative_period
+      alias current_term latest_legislative_period
     end
   end
 end

--- a/lib/everypolitician/popolo/version.rb
+++ b/lib/everypolitician/popolo/version.rb
@@ -1,5 +1,5 @@
 module Everypolitician
   module Popolo
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.8.0'.freeze
   end
 end

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -19,12 +19,20 @@ class JsonTest < Minitest::Test
     assert_equal 'Term 2', popolo_json.latest_legislative_period.name
   end
 
+  def test_current_legislative_period_returns_correct_term
+    assert_equal 'Term 2', popolo_json.current_legislative_period.name
+  end
+
   def test_that_terms_returns_the_same_as_legislative_periods
     assert_equal popolo_json.terms, popolo_json.legislative_periods
   end
 
   def test_latest_term_returns_the_same_as_latest_legislative_period
     assert_equal popolo_json.latest_term, popolo_json.latest_legislative_period
+  end
+
+  def test_current_legislative_period_returns_the_same_as_latest_legislative_period
+    assert_equal popolo_json.current_legislative_period, popolo_json.latest_legislative_period
   end
 
   def test_that_terms_returns_only_legislative_period_objects

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -15,16 +15,16 @@ class JsonTest < Minitest::Test
     assert_equal 2, popolo_json.legislative_periods.count
   end
 
-  def test_current_legislative_period_returns_correct_term
-    assert_equal 'Term 2', popolo_json.current_legislative_period.name
+  def test_latest_legislative_period_returns_correct_term
+    assert_equal 'Term 2', popolo_json.latest_legislative_period.name
   end
 
   def test_that_terms_returns_the_same_as_legislative_periods
     assert_equal popolo_json.terms, popolo_json.legislative_periods
   end
 
-  def test_current_term_returns_the_same_as_current_legislative_period
-    assert_equal popolo_json.current_term, popolo_json.current_legislative_period
+  def test_latest_term_returns_the_same_as_latest_legislative_period
+    assert_equal popolo_json.latest_term, popolo_json.latest_legislative_period
   end
 
   def test_that_terms_returns_only_legislative_period_objects


### PR DESCRIPTION
This changes `current_legislature` and `current_term` to `latest_legislature` and `latest_term` while leaving the `current_` versions but notes that they are deprecated.

Fixes #78
