### PR TITLE
return collections from of_class

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -58,7 +58,7 @@ module Everypolitician
       alias terms legislative_periods
 
       def current_legislative_period
-        legislative_periods.last
+        legislative_periods.max_by(&:start_date)
       end
       alias current_term current_legislative_period
     end

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -41,8 +41,8 @@ module Everypolitician
         count.zero?
       end
 
-      def of_class(klass)
-        @of_class[klass] ||= select { |e| e.class == klass }
+      def of_class(klass, collection = self)
+        @of_class[klass] ||= new_collection(select { |e| e.class == klass }, collection)
       end
 
       private

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -51,8 +51,8 @@ module Everypolitician
         @indexes[attr] ||= group_by(&attr)
       end
 
-      def new_collection(entities)
-        self.class.new(entities.to_a.map(&:document), popolo)
+      def new_collection(entities, klass = self.class)
+        klass.new(entities.to_a.map(&:document), popolo)
       end
 
       def class_for_entity(_document)

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -17,7 +17,7 @@ module Everypolitician
         @documents = documents ? documents.map { |p| class_for_entity(p).new(p, popolo) } : []
         @popolo = popolo
         @indexes = {}
-        @of_class = {}
+        @of_collection = {}
       end
 
       def each(&block)
@@ -41,8 +41,8 @@ module Everypolitician
         count.zero?
       end
 
-      def of_class(klass, collection = self)
-        @of_class[klass] ||= new_collection(select { |e| e.class == klass }, collection)
+      def of_collection(collection)
+        @of_collection[collection] ||= new_collection(select { |e| e.class == collection.entity_class }, collection)
       end
 
       private

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -26,11 +26,11 @@ module Everypolitician
       entity_class Event
 
       def elections
-        of_class(Election)
+        of_class(Election, Elections)
       end
 
       def legislative_periods
-        of_class(LegislativePeriod)
+        of_class(LegislativePeriod, LegislativePeriods)
       end
 
       def class_for_entity(document)

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -26,11 +26,11 @@ module Everypolitician
       entity_class Event
 
       def elections
-        of_class(Election, Elections)
+        of_collection(Elections)
       end
 
       def legislative_periods
-        of_class(LegislativePeriod, LegislativePeriods)
+        of_collection(LegislativePeriods)
       end
 
       def class_for_entity(document)

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -33,6 +33,7 @@ class EventTest < Minitest::Test
 
   def test_accessing_legislative_periods
     terms = popolo.legislative_periods
+    assert_instance_of Everypolitician::Popolo::LegislativePeriods, terms
     assert_equal 2, terms.count
     term = terms.first
     assert_instance_of Everypolitician::Popolo::LegislativePeriod, term

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -41,6 +41,7 @@ class EventTest < Minitest::Test
 
   def test_accessing_elections
     elections = popolo.elections
+    assert_instance_of Everypolitician::Popolo::Elections, elections
     assert_equal 14, elections.count
     election = elections.first
     assert_instance_of Everypolitician::Popolo::Election, election


### PR DESCRIPTION
`of_class` was returning arrays so update it to return collections, at the same time updating `new_collection` to accept an option collection class to instantiate. This means that if you are fetching a collection of sub-classes then you can instantiate the correct collection.

At the moment this is manual so for `of_class` you have to specify both the Entity class and the Collection class because it's not clear how to link the two. I'm not sure it's possible to specify a `collection_class` property for an `Entity` because of ordering - e.g. the `Elections` class is defined after `Election` so can't be used in `Election`.

Fixes #116
