### PR TITLE
Enable warnings in tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
 Rake::TestTask.new(:test) do |t|
+  t.warning = true
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']


### PR DESCRIPTION
This will print out any warnings that our code is generating before running the tests.

Essentially the same change as https://github.com/everypolitician/everypolitician-ruby/pull/69
