### PR TITLE
Handle events with no start date

### DIFF
--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -37,7 +37,7 @@ module Everypolitician
 
       def events
         # do the sorting at the popolo level so we still get an Events object back
-        @events ||= Events.new(popolo[:events].to_a.sort_by { |e| e[:start_date] }, self)
+        @events ||= Events.new(popolo[:events].to_a.sort_by { |e| e[:start_date].to_s }, self)
       end
 
       def posts

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -64,4 +64,11 @@ class EventTest < Minitest::Test
     assert_equal org_ids.count, 1
     assert_equal org_ids.first, '1ba661a9-22ad-4d0f-8a60-fe8e28f2488c'
   end
+
+  def test_events_with_no_start_date
+    estonia = JSON.parse(File.read('test/fixtures/estonia-ep-popolo-v1.0.json'), symbolize_names: true)
+    estonia[:events].first.delete(:start_date)
+    popolo = EveryPolitician::Popolo::JSON.new(estonia)
+    assert_nil popolo.events.first.start_date
+  end
 end


### PR DESCRIPTION
This means that calling `Everypolitician::Popolo::JSON#events` won't
raise an exception when an event is missing a `start_date` attribute.

Previously an exception was being raised when some events had a start
date and some didn't because `#sort_by` was trying to compare a string
with `nil`, which was causing the following error:

    ArgumentError: comparison of NilClass with String failed

By casting the `start_date` to a string in the `#sort_by` block we can
avoid this problem.

Fixes https://github.com/everypolitician/everypolitician-popolo/issues/120