### PR TITLE
Remove redefinition of the identifiers method in Person

### DIFF
--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -91,10 +91,6 @@ module Everypolitician
         document.fetch(:patronymic_name, nil)
       end
 
-      def identifiers
-        document.fetch(:identifiers, [])
-      end
-
       def images
         document.fetch(:images, [])
       end


### PR DESCRIPTION
Since the `Person` class is a subclass of an `Entity`, and `Entity` defines
the `identifiers` method already, there is no need to redefine it in
the subclass again.