### PR TITLE
Remove redefinition of the wikidata method in Area

### DIFF
--- a/lib/everypolitician/popolo/area.rb
+++ b/lib/everypolitician/popolo/area.rb
@@ -16,10 +16,6 @@ module Everypolitician
       def type
         document.fetch(:type, nil)
       end
-
-      def wikidata
-        identifier('wikidata')
-      end
     end
 
     class Areas < Collection


### PR DESCRIPTION
Since the Area class is a subclass of an Entity, and Entity defines
the identifiers method already, there is no need to redefine it in
the subclass again.