### PR TITLE
Replace "assert_equal nil" with "assert_nil"

### DIFF
--- a/test/everypolitician/popolo/area_test.rb
+++ b/test/everypolitician/popolo/area_test.rb
@@ -44,7 +44,7 @@ class AreaTest < Minitest::Test
   def test_type
     # we don't have any data that has a missing area type so generate one
     area = Everypolitician::Popolo::Area.new(id: 'an_area', name: 'An Area')
-    assert_equal nil, area.type
+    assert_nil area.type
     assert_equal 'constituency', tartu.type
   end
 
@@ -63,7 +63,7 @@ class AreaTest < Minitest::Test
   end
 
   def test_wikidata
-    assert_equal nil, adana.wikidata
+    assert_nil adana.wikidata
     assert_equal 'Q3032626', tartu.wikidata
   end
 end

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -18,12 +18,12 @@ class CollectionTest < Minitest::Test
   end
 
   def test_find_by_finding_no_item
-    assert_equal nil, popolo.persons.find_by(name: 'Raavi Tõivas')
+    assert_nil popolo.persons.find_by(name: 'Raavi Tõivas')
   end
 
   def test_find_by_finding_an_organization_by_multiple_attributes
     assert_equal 'SDE', popolo.organizations.find_by(id: 'SDE', name: 'Sotsiaaldemokraatliku Erakonna fraktsioon').id
-    assert_equal nil, popolo.organizations.find_by(id: 'IRL', name: 'Sotsiaaldemokraatliku Erakonna fraktsioon')
+    assert_nil popolo.organizations.find_by(id: 'IRL', name: 'Sotsiaaldemokraatliku Erakonna fraktsioon')
   end
 
   def test_where_finding_multiple_parties

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -35,7 +35,7 @@ class MembershipTest < Minitest::Test
 
   def test_membership_with_no_start_date
     with_no_start_date = memberships.partition(&:start_date).last
-    assert_equal nil, with_no_start_date.first.start_date
+    assert_nil with_no_start_date.first.start_date
   end
 
   def test_membership_with_end_date
@@ -45,7 +45,7 @@ class MembershipTest < Minitest::Test
 
   def test_membership_with_no_end_date
     with_no_end_date = memberships.partition(&:end_date).last
-    assert_equal nil, with_no_end_date.first.end_date
+    assert_nil with_no_end_date.first.end_date
   end
 
   def test_membership_person
@@ -81,12 +81,12 @@ class MembershipTest < Minitest::Test
   end
 
   def test_membership_post_id
-    assert_equal nil, memberships.first.post_id
+    assert_nil memberships.first.post_id
     assert_equal "women's_representative", nyeri.post_id
   end
 
   def test_membership_post
-    assert_equal nil, memberships.first.post
+    assert_nil memberships.first.post
     assert_instance_of Everypolitician::Popolo::Post, nyeri.post
     assert_equal "Women's Representative", nyeri.post.label
   end

--- a/test/everypolitician/popolo/organization_test.rb
+++ b/test/everypolitician/popolo/organization_test.rb
@@ -79,17 +79,17 @@ class OrganizationTest < Minitest::Test
   end
 
   def test_seats
-    assert_equal nil, irl.seats
+    assert_nil irl.seats
     assert_equal 101, riigikogu.seats
   end
 
   def test_srgb
-    assert_equal nil, irl.srgb
+    assert_nil irl.srgb
     assert_equal '008800', sinn_fein.srgb
   end
 
   def test_associated_colour
-    assert_equal nil, irl.associated_colour
+    assert_nil irl.associated_colour
     assert_equal '008800', sinn_fein.associated_colour
   end
 

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -76,12 +76,12 @@ class PersonTest
 
   def test_twitter
     assert_equal 'taaviroivas', taavi.twitter
-    assert_equal nil, eiki.twitter
+    assert_nil eiki.twitter
   end
 
   def test_facebook
     assert_equal 'https://facebook.com/100000658185044', eiki.facebook
-    assert_equal nil, taavi.facebook
+    assert_nil taavi.facebook
   end
 
   # TODO: switch this test to be against live data
@@ -118,17 +118,17 @@ class PersonTest
   def test_contacts
     assert_equal '6316301', eiki.contact('phone')
     assert_equal '6316301', eiki.phone
-    assert_equal nil, eiki.fax
+    assert_nil eiki.fax
   end
 
   def test_no_contacts
-    assert_equal nil, taavi.contact('phone')
-    assert_equal nil, taavi.phone
-    assert_equal nil, taavi.fax
+    assert_nil taavi.contact('phone')
+    assert_nil taavi.phone
+    assert_nil taavi.fax
   end
 
   def test_sort_name
-    assert_equal nil, taavi['sort_name']
+    assert_nil taavi['sort_name']
     assert_equal 'Taavi Rõivas', taavi.sort_name
   end
 
@@ -141,7 +141,7 @@ class PersonTest
   end
 
   def test_patronynic_name
-    assert_equal nil, eiki.patronymic_name
+    assert_nil eiki.patronymic_name
     assert_equal 'd/o Shams-ul-Qayum Wazir', aaisha.patronymic_name
   end
 
@@ -151,32 +151,32 @@ class PersonTest
 
   def test_image
     assert_equal 'http://www.riigikogu.ee/wpcms/wp-content/uploads/ems/temp/8a941c7a-8333-484b-a720-8207dee2e4cc.jpg', eiki.image
-    assert_equal nil, etti.image
+    assert_nil etti.image
   end
 
   def test_gender
     assert_equal 'male', taavi.gender
-    assert_equal nil, etti.gender
+    assert_nil etti.gender
   end
 
   def test_national_identity
-    assert_equal nil, etti.national_identity
+    assert_nil etti.national_identity
     assert_equal 'HUTU', ahishakiye.national_identity
   end
 
   def test_summary
-    assert_equal nil, etti.summary
+    assert_nil etti.summary
     assert_equal 'Bulawayo Province Member of the Senate.', agnes.summary
   end
 
   def test_honorific_prefix
-    assert_equal nil, taavi.honorific_prefix
+    assert_nil taavi.honorific_prefix
     person = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob', honorific_prefix: 'Dr')
     assert_equal 'Dr', person.honorific_prefix
   end
 
   def test_honorific_suffix
-    assert_equal nil, taavi.honorific_suffix
+    assert_nil taavi.honorific_suffix
     person = Everypolitician::Popolo::Person.new(id: '123', name: 'Bob', honorific_suffix: 'PhD')
     assert_equal 'PhD', person.honorific_suffix
   end


### PR DESCRIPTION
I was getting this nasty warnings when running the tests:

![assert_nil](https://cloud.githubusercontent.com/assets/2157089/24956696/bc7ba5da-1f80-11e7-8cbd-804a5316da48.png)

So I replaced all occurrences of `assert_equal nil` with `assert_nil`:

![now](https://cloud.githubusercontent.com/assets/2157089/24956743/f36a69f0-1f80-11e7-84b3-2f7f6027d554.png)

That should be less annoying.