### PR TITLE
Update to rubocop 0.52

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ script:
   - bundle exec rake rubocop
 cache: bundler
 rvm:
-  - 2.0.0
   - 2.1.8
   - 2.2.4
   - 2.3.0

--- a/everypolitician-popolo.gemspec
+++ b/everypolitician-popolo.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'everypolitician/popolo/version'
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'require_all'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.52.0'
 end

--- a/everypolitician-popolo.gemspec
+++ b/everypolitician-popolo.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'rubocop', '~> 0.42.0'
+  spec.add_development_dependency 'rubocop', '~> 0.52.0'
 end

--- a/test/everypolitician/popolo/person_behaviour.rb
+++ b/test/everypolitician/popolo/person_behaviour.rb
@@ -31,10 +31,10 @@ class PersonTestBehaviour
   end
 
   def test_persons_subtraction
-    person1 = { id: '123', name: 'Alice' }
-    person2 = { id: '456', name: 'Bob', gender: 'male' }
-    all_people = Everypolitician::Popolo::People.new([person1, person2])
-    just_person_1 = Everypolitician::Popolo::People.new([person1])
-    assert_equal [Everypolitician::Popolo::Person.new(person2)], all_people - just_person_1
+    alice = { id: '123', name: 'Alice' }
+    bob = { id: '456', name: 'Bob', gender: 'male' }
+    all_people = Everypolitician::Popolo::People.new([alice, bob])
+    only_alice = Everypolitician::Popolo::People.new([alice])
+    assert_equal [Everypolitician::Popolo::Person.new(bob)], all_people - only_alice
   end
 end


### PR DESCRIPTION
As well as being good to keep in sync generally, there's a known security
vulnerability with 0.42