### PR TITLE
0.8.1 Explicitly require parent classes

### DIFF
--- a/everypolitician-popolo.gemspec
+++ b/everypolitician-popolo.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'require_all', '~> 1.0'
+  spec.add_dependency 'require_all'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/lib/everypolitician/popolo/area.rb
+++ b/lib/everypolitician/popolo/area.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'collection'
+require_relative 'entity'
+
 module Everypolitician
   module Popolo
     class Area < Entity

--- a/lib/everypolitician/popolo/election.rb
+++ b/lib/everypolitician/popolo/election.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'collection'
+require_relative 'event'
+
 module Everypolitician
   module Popolo
     class Election < Event

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'collection'
+require_relative 'entity'
+
 module Everypolitician
   module Popolo
     class Event < Entity

--- a/lib/everypolitician/popolo/legislative_period.rb
+++ b/lib/everypolitician/popolo/legislative_period.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'collection'
+require_relative 'event'
+
 module Everypolitician
   module Popolo
     class LegislativePeriod < Event

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'collection'
+require_relative 'entity'
+
 module Everypolitician
   module Popolo
     class Membership < Entity

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'collection'
+require_relative 'entity'
+
 module Everypolitician
   module Popolo
     class Organization < Entity

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'collection'
+require_relative 'entity'
+
 module Everypolitician
   module Popolo
     class Person < Entity

--- a/lib/everypolitician/popolo/post.rb
+++ b/lib/everypolitician/popolo/post.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'collection'
+require_relative 'entity'
+
 module Everypolitician
   module Popolo
     class Post < Entity

--- a/lib/everypolitician/popolo/version.rb
+++ b/lib/everypolitician/popolo/version.rb
@@ -2,6 +2,6 @@
 
 module Everypolitician
   module Popolo
-    VERSION = '0.8.0'.freeze
+    VERSION = '0.8.1'.freeze
   end
 end


### PR DESCRIPTION
`require_all` no longer lets us rely on these having been previously
loaded, so we need to explicitly require the files we're using.

Fixes #127