### PR TITLE
Update to rubocop 0.53

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.1
+
 inherit_from:
   - https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/.rubocop_base.yml
   - .rubocop_todo.yml
-
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in everypolitician-popolo.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'everypolitician/popolo'

--- a/everypolitician-popolo.gemspec
+++ b/everypolitician-popolo.gemspec
@@ -1,5 +1,7 @@
 
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'everypolitician/popolo/version'
 
@@ -18,11 +20,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'require_all'
+  spec.add_dependency 'require_all', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.52.0'
+  spec.add_development_dependency 'rubocop', '~> 0.53.0'
 end

--- a/lib/everypolitician/popolo.rb
+++ b/lib/everypolitician/popolo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'require_all'
 

--- a/lib/everypolitician/popolo/area.rb
+++ b/lib/everypolitician/popolo/area.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class Area < Entity

--- a/lib/everypolitician/popolo/collection.rb
+++ b/lib/everypolitician/popolo/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class Collection

--- a/lib/everypolitician/popolo/election.rb
+++ b/lib/everypolitician/popolo/election.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class Election < Event

--- a/lib/everypolitician/popolo/entity.rb
+++ b/lib/everypolitician/popolo/entity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class Entity

--- a/lib/everypolitician/popolo/event.rb
+++ b/lib/everypolitician/popolo/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class Event < Entity

--- a/lib/everypolitician/popolo/legislative_period.rb
+++ b/lib/everypolitician/popolo/legislative_period.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class LegislativePeriod < Event

--- a/lib/everypolitician/popolo/membership.rb
+++ b/lib/everypolitician/popolo/membership.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class Membership < Entity

--- a/lib/everypolitician/popolo/organization.rb
+++ b/lib/everypolitician/popolo/organization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class Organization < Entity

--- a/lib/everypolitician/popolo/person.rb
+++ b/lib/everypolitician/popolo/person.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class Person < Entity

--- a/lib/everypolitician/popolo/post.rb
+++ b/lib/everypolitician/popolo/post.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     class Post < Entity

--- a/lib/everypolitician/popolo/version.rb
+++ b/lib/everypolitician/popolo/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Everypolitician
   module Popolo
     VERSION = '0.8.0'.freeze

--- a/test/everypolitician/popolo/area_test.rb
+++ b/test/everypolitician/popolo/area_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class AreaTest < Minitest::Test

--- a/test/everypolitician/popolo/collection_test.rb
+++ b/test/everypolitician/popolo/collection_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CollectionTest < Minitest::Test

--- a/test/everypolitician/popolo/event_test.rb
+++ b/test/everypolitician/popolo/event_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 class EventTest < Minitest::Test
   def popolo

--- a/test/everypolitician/popolo/json_test.rb
+++ b/test/everypolitician/popolo/json_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class JsonTest < Minitest::Test

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -12,7 +12,7 @@ class MembershipTest < Minitest::Test
   end
 
   def memberships
-    @mems ||= Everypolitician::Popolo.read(fixture).memberships
+    @memberships ||= Everypolitician::Popolo.read(fixture).memberships
   end
 
   def nyeri

--- a/test/everypolitician/popolo/membership_test.rb
+++ b/test/everypolitician/popolo/membership_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MembershipTest < Minitest::Test

--- a/test/everypolitician/popolo/organization_test.rb
+++ b/test/everypolitician/popolo/organization_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class OrganizationTest < Minitest::Test

--- a/test/everypolitician/popolo/person_behaviour.rb
+++ b/test/everypolitician/popolo/person_behaviour.rb
@@ -8,7 +8,7 @@ class PersonTestBehaviour
   end
 
   def people
-    @ppl ||= Everypolitician::Popolo.read(estonia_fixture).persons
+    @people ||= Everypolitician::Popolo.read(estonia_fixture).persons
   end
 
   def taavi

--- a/test/everypolitician/popolo/person_behaviour.rb
+++ b/test/everypolitician/popolo/person_behaviour.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PersonTestBehaviour

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -20,19 +20,19 @@ class PersonTest
   end
 
   def people
-    @ppl ||= Everypolitician::Popolo.read(estonia_fixture).persons
+    @people ||= Everypolitician::Popolo.read(estonia_fixture).persons
   end
 
   def pakistan_people
-    @pakistan_ppl ||= Everypolitician::Popolo.read(pakistan_fixture).persons
+    @pakistan_people ||= Everypolitician::Popolo.read(pakistan_fixture).persons
   end
 
   def burundi_people
-    @burundi_ppl ||= Everypolitician::Popolo.read(burundi_fixture).persons
+    @burundi_people ||= Everypolitician::Popolo.read(burundi_fixture).persons
   end
 
   def zimbabwe_people
-    @zimbabwe_ppl ||= Everypolitician::Popolo.read(zimbabwe_fixture).persons
+    @zimbabwe_people ||= Everypolitician::Popolo.read(zimbabwe_fixture).persons
   end
 
   def aadu

--- a/test/everypolitician/popolo/person_test.rb
+++ b/test/everypolitician/popolo/person_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PersonTest

--- a/test/everypolitician/popolo/post_test.rb
+++ b/test/everypolitician/popolo/post_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PostTest < Minitest::Test

--- a/test/everypolitician/popolo_test.rb
+++ b/test/everypolitician/popolo_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PopoloTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'everypolitician/popolo'
 require 'pry'
 


### PR DESCRIPTION
We also need to temporarily pin require_all to 1.x, as 2.0 isn't backwards
compat. We're fixing that separately in #128

Fixes #129